### PR TITLE
Enhance search template handling and UI title normalization

### DIFF
--- a/medusa/search_templates.py
+++ b/medusa/search_templates.py
@@ -271,6 +271,11 @@ class SearchTemplates(object):
         self.templates = []
         self.remove_custom()
         for template in templates:
+            # Normalize UI title variants (e.g. "Show Name (2020)") to the canonical show name.
+            template = dict(template)
+            if template.get('title') == self.show_obj.title and self.show_obj.title != self.show_obj.name:
+                template['title'] = self.show_obj.name
+
             # TODO: add validation
             # Check if the scene exception still exists in db
             find_scene_exception = self.main_db_con.select(

--- a/themes-default/slim/src/components/helpers/search-template-container.vue
+++ b/themes-default/slim/src/components/helpers/search-template-container.vue
@@ -441,7 +441,12 @@ export default {
              * Add new template to the array of searchTemplates.
              */
             const { show, addSearchTemplate } = this;
-            if (this.searchTemplates.find(t => t.template === template.pattern && t.title === template.title)) {
+            if (this.searchTemplates.find(t => (
+                t.template === template.pattern &&
+                t.title === template.title.title &&
+                t.season === template.title.season &&
+                Boolean(t.seasonSearch) === Boolean(template.seasonSearch)
+            ))) {
                 this.$snotify.error(
                     'Error while trying to add the template',
                     "Can't add a pattern that already exists!"

--- a/themes-default/slim/src/components/helpers/search-template-custom.vue
+++ b/themes-default/slim/src/components/helpers/search-template-custom.vue
@@ -178,13 +178,13 @@ export default {
     },
     mounted() {
         const { show } = this;
-        const { title } = show;
+        const { name } = show;
 
         this.selectedTitle = {
             indexer: show.indexer,
             seriesId: show.id[show.indexer],
             season: -1,
-            title
+            title: name
         };
     },
     computed: {
@@ -193,14 +193,14 @@ export default {
         }),
         selectTitles() {
             const { show } = this;
-            const { config, title } = show;
+            const { config, name } = show;
             const { aliases } = config;
 
             const titleOption = {
                 indexer: show.indexer,
                 seriesId: show.id[show.indexer],
                 season: -1,
-                title
+                title: name
             };
 
             return [...[titleOption], ...aliases];
@@ -295,7 +295,7 @@ export default {
                 enabled,
                 selectedTitle
             } = this;
-            const { title } = show;
+            const { name } = show;
 
             this.$emit('input', {
                 pattern: `%SN${addPattern}`,
@@ -308,7 +308,7 @@ export default {
                 indexer: show.indexer,
                 seriesId: show.id[show.indexer],
                 season: -1,
-                title
+                title: name
             };
             this.addPattern = '';
             this.episodeOrSeason = 'episode';

--- a/themes-default/slim/src/store/modules/shows.js
+++ b/themes-default/slim/src/store/modules/shows.js
@@ -181,8 +181,13 @@ const mutations = {
         // Get current show object
         const currentShow = Object.assign({}, state.shows.find(({ id, indexer }) => Number(show.id[show.indexer]) === Number(id[indexer])));
 
-        if (currentShow.config.searchTemplates.find(t => t.template === template.pattern)) {
-            console.warn(`Can't add template (${template.pattern} to show ${currentShow.title} as it already exists.`);
+        if (currentShow.config.searchTemplates.find(t => (
+            t.template === template.template &&
+            t.title === template.title &&
+            t.season === template.season &&
+            Boolean(t.seasonSearch) === Boolean(template.seasonSearch)
+        ))) {
+            console.warn(`Can't add template (${template.template}) to show ${currentShow.title} as it already exists.`);
             return;
         }
 


### PR DESCRIPTION
- Normalize UI title variants in search templates to match the canonical show name.
- Update search template comparison logic to include season and seasonSearch properties.
- Refactor show title references to use the 'name' property instead of 'title' in multiple components.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
