### PR TITLE
fix: restore Dredd API contract tests

### DIFF
--- a/dredd/api-description.yml
+++ b/dredd/api-description.yml
@@ -48,6 +48,10 @@ paths:
               description: The location of the newly added series
           schema:
             $ref: '#/definitions/Series'
+          x-request:
+            body:
+              id:
+                tvdb: 80379
         400:
           $ref: '#/responses/error'
           description: Invalid request
@@ -185,6 +189,9 @@ paths:
         409:
           $ref: '#/responses/error'
           description: Unable to delete series
+          x-request:
+            path-params:
+              id: tvdb301825
   /series/{id}/{field}:
     get:
       summary: Return a specific field from a given series
@@ -226,7 +233,6 @@ paths:
           required: false
           description: The episode season
           type: integer
-          format: int32
         - $ref: '#/parameters/detailed'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/limit'
@@ -262,7 +268,6 @@ paths:
           required: false
           description: The episode season
           type: integer
-          format: int32
       responses:
         207:
           description: Response with the status of the single patches
@@ -348,7 +353,7 @@ paths:
           x-request:
             path-params:
               seriesid: tvdb301824
-              id: s9999e9999
+              id: e9999
         409:
           $ref: '#/responses/error'
           description: Unable to delete episode
@@ -409,7 +414,7 @@ paths:
           description: Series or episode not found
           x-request:
             path-params:
-              id: s99e99
+              id: e9999
   /series/{seriesid}/asset/{id}:
     get:
       summary: Return a specific asset from a given series
@@ -486,7 +491,6 @@ paths:
           required: false
           description: The season number
           type: integer
-          format: int32
         - name: type
           in: query
           required: false
@@ -902,18 +906,19 @@ paths:
           x-request:
             body:
               showSlug: tvdb301824
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
         400:
           $ref: '#/responses/error'
           x-request:
             body:
-              episodes: [s01e01", "s01e02"]
+              showSlug: invalid-slug
+              episodes: ["s01e01", "s01e02"]
         404:
           $ref: '#/responses/error'
           x-request:
             body:
               showSlug: tvdb12345
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
   /search/failed:
     put:
       summary: Search providers for results
@@ -930,18 +935,18 @@ paths:
           x-request:
             body:
               showSlug: tvdb301824
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
         400:
           $ref: '#/responses/error'
           x-request:
             body:
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
         404:
           $ref: '#/responses/error'
           x-request:
             body:
               showSlug: tvdb12345
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
   /search/manual:
     put:
       summary: Search providers for results
@@ -956,18 +961,18 @@ paths:
           x-request:
             body:
               showSlug: tvdb301824
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
         400:
           $ref: '#/responses/error'
           x-request:
             body:
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
         404:
           $ref: '#/responses/error'
           x-request:
             body:
               showSlug: tvdb12345
-              episodes: [s01e01", "s01e02"]
+              episodes: ["s01e01", "s01e02"]
   /search/daily:
     put:
       summary: Queue a forced daily search
@@ -1091,12 +1096,10 @@ definitions:
         properties:
           tvdb:
             type: integer
-            format: int32
             minimum: 1
             description: This is the ID from thetvdb.com
           tvmaze:
             type: integer
-            format: int32
             minimum: 1
             description: This is the ID from tvmaze.com
           imdb:
@@ -1194,13 +1197,11 @@ definitions:
         properties:
           start:
             type: integer
-            format: int32
             minimum: 1900
             maximum: 2200
             description: Starting year
           end:
             type: integer
-            format: int32
             minimum: 1900
             maximum: 2200
             description: End year. Available in detailed view
@@ -1212,7 +1213,6 @@ definitions:
       runtime:
         type: integer
         minimum: 1
-        format: int32
         description: Episodes runtime in minutes
       genres:
         type: array
@@ -1230,7 +1230,6 @@ definitions:
                 description: "IMDB's star rating from 0 to 10"
               votes:
                 type: integer
-                format: int32
                 minimum: 1
                 description: "Total number of votes"
         example:
@@ -1275,12 +1274,10 @@ definitions:
                 type: array
                 items:
                   type: integer
-                  format: int32
               preferred:
                 type: array
                 items:
                   type: integer
-                  format: int32
           paused:
             type: boolean
             description: Whether series is paused
@@ -1346,7 +1343,6 @@ definitions:
           properties:
             season:
               type: integer
-              format: int32
               description: Season number
             episodes:
               type: array
@@ -1380,11 +1376,9 @@ definitions:
           properties:
             absolute:
               type: integer
-              format: int32
               description: Absolute episode number.
             sceneAbsolute:
               type: integer
-              format: int32
               description: Scene absolute episode number.
       xemAbsoluteNumbering:
         type: array
@@ -1396,11 +1390,9 @@ definitions:
           properties:
             absolute:
               type: integer
-              format: int32
               description: Absolute episode number.
             sceneAbsolute:
               type: integer
-              format: int32
               description: Scene absolute episode number.
       sceneNumbering:
         type: array
@@ -1418,11 +1410,9 @@ definitions:
         properties:
           tvdb:
             type: integer
-            format: int32
             description: This is the ID from thetvdb.com
           tvmaze:
             type: integer
-            format: int32
             description: This is the ID from tvmaze.com
           imdb:
             type: string
@@ -1433,17 +1423,14 @@ definitions:
           imdb: tt0123
       season:
         type: integer
-        format: int32
         minimum: 0
         maximum: 1000
       episode:
         type: integer
-        format: int32
         minimum: 0
         maximum: 10000
       absoluteNumber:
         type: integer
-        format: int32
         minimum: 1
         maximum: 10000
       airDate:
@@ -1489,7 +1476,6 @@ definitions:
             description: Whether the release is proper
           version:
             type: integer
-            format: int32
             minimum: 0
             maximum: 10
             description: Episode version (common in animes)
@@ -1498,17 +1484,14 @@ definitions:
         properties:
           season:
             type: integer
-            format: int32
             minimum: 0
             maximum: 1000
           episode:
             type: integer
-            format: int32
             minimum: 0
             maximum: 10000
           absoluteNumber:
             type: integer
-            format: int32
             minimum: 1
             maximum: 10000
       file:
@@ -1521,7 +1504,6 @@ definitions:
             example: '/library/My Series/Season 10/My Series - S03E07 - Super Episode.avi'
           size:
             type: integer
-            format: int64
             minimum: 1
             description: The file size in bytes
       statistics:
@@ -1538,7 +1520,6 @@ definitions:
                 description: Last subtitle search timestamp
               count:
                 type: integer
-                format: int32
                 minimum: 0
                 description: search count
       relatedEpisodes:
@@ -1572,7 +1553,6 @@ definitions:
     properties:
       code:
         type: integer
-        format: int32
       message:
         type: string
       fields:
@@ -2474,12 +2454,10 @@ definitions:
         example: '0:19:39.208000'
       size:
         type: integer
-        format: int64
         minimum: 0
         description: Video file size in bytes
       overall_bit_rate:
         type: integer
-        format: int32
         minimum: 0
         description: Video overall bitrate
       video:
@@ -2489,7 +2467,6 @@ definitions:
           properties:
             number:
               type: integer
-              format: int32
               minimum: 0
               description: Track number
             name:
@@ -2503,17 +2480,14 @@ definitions:
               description: Track duration
             size:
               type: integer
-              format: int64
               minimum: 0
               description: Video stream size in bytes
             width:
               type: integer
-              format: int32
               minimum: 0
               description: Video width size (pixels)
             height:
               type: integer
-              format: int32
               minimum: 0
               description: Video height size (pixels)
             scan_type:
@@ -2556,12 +2530,10 @@ definitions:
               description: Video frame rate (frames per second)
             bit_depth:
               type: integer
-              format: int32
               minimum: 0
               description: Video bit depth
             bit_rate:
               type: integer
-              format: int32
               minimum: 0
               description: Video bit rate
             codec:
@@ -2609,7 +2581,6 @@ definitions:
           properties:
             number:
               type: integer
-              format: int32
               minimum: 0
               description: Track number
             name:
@@ -2623,7 +2594,6 @@ definitions:
               description: Track duration
             size:
               type: integer
-              format: int64
               minimum: 0
               description: Audio stream size in bytes
             codec:
@@ -2654,7 +2624,6 @@ definitions:
                 - LC
             channels_count:
               type: integer
-              format: int32
               minimum: 0
               description: Number of channels
             channel_positions:
@@ -2670,12 +2639,10 @@ definitions:
                 - "7.1"
             bit_depth:
               type: integer
-              format: int32
               minimum: 0
               description: Audio bit depth
             bit_rate:
               type: integer
-              format: int32
               minimum: 0
               description: Audio bit rate
             bit_rate_mode:
@@ -2683,7 +2650,6 @@ definitions:
               enum: [Constant, Variable]
             sampling_rate:
               type: integer
-              format: int32
               description: Audio sampling rate
             compression:
               type: string
@@ -2702,7 +2668,6 @@ definitions:
           properties:
             number:
               type: integer
-              format: int32
               minimum: 0
               description: Track number
             name:
@@ -2746,12 +2711,10 @@ definitions:
         properties:
           season:
             type: integer
-            format: int32
             minimum: 0
             maximum: 1000
           episode:
             type: integer
-            format: int32
             minimum: 0
             maximum: 10000
       destination:
@@ -2759,12 +2722,10 @@ definitions:
         properties:
           season:
             type: integer
-            format: int32
             minimum: 0
             maximum: 1000
           episode:
             type: integer
-            format: int32
             minimum: 0
             maximum: 10000
   SearchedEpisode:
@@ -2772,23 +2733,18 @@ definitions:
     properties:
       indexer:
         type: integer
-        format: int32
         description: Internal id for the shows indexer
       series_id:
         type: integer
-        format: int32
         description: Unique id for the show from a shows indexer
       episode:
         type: integer
-        format: int32
         description: Episode number
       season:
         type: integer
-        format: int32
         description: Season number
       episodeindexerid:
         type: integer
-        format: int32
         description: Unique id for the episode from a shows indexer
       searchstatus:
         enum:
@@ -2812,21 +2768,18 @@ definitions:
     properties:
       id:
         type: integer
-        format: int32
         description: Internal id for the history row
       series:
         type: string
         description: Series slug (if available)
       status:
         type: integer
-        format: int32
         description: Status (numberic)
       statusName:
         type: string
         description: Status description
       actionDate:
         type: integer
-        format: int32
         description: Date of when the history entrie was stored
       resource:
         type: string
@@ -2869,14 +2822,12 @@ parameters:
     required: false
     description: The page to be returned. Default value is 1
     type: integer
-    format: int32
   limit:
     name: limit
     in: query
     required: false
     description: Maximum number of items per page. Default value is 20. Max value is 1000
     type: integer
-    format: int32
   sort:
     name: sort
     in: query
@@ -2911,7 +2862,6 @@ parameters:
     description: The alias id to retrieve
     x-example: 123456
     type: integer
-    format: int32
   alias-source-id:
     name: alias-source-id
     in: path
@@ -3023,15 +2973,12 @@ responses:
     headers:
       X-Pagination-Page:
         type: integer
-        format: int32
         description: The page number
       X-Pagination-Limit:
         type: integer
-        format: int32
         description: The pagination limit
       X-Pagination-Count:
         type: integer
-        format: int32
         description: The total items count
       Link:
         type: string
@@ -3041,11 +2988,9 @@ responses:
     headers:
       X-Pagination-Page:
         type: integer
-        format: int32
         description: The page number
       X-Pagination-Limit:
         type: integer
-        format: int32
         description: The pagination limit
       Link:
         type: string
@@ -3059,15 +3004,12 @@ responses:
     headers:
       X-Pagination-Page:
         type: integer
-        format: int32
         description: The page number
       X-Pagination-Limit:
         type: integer
-        format: int32
         description: The pagination limit
       X-Pagination-Count:
         type: integer
-        format: int32
         description: The total items count
       Link:
         type: string

--- a/dredd/dredd_hook.py
+++ b/dredd/dredd_hook.py
@@ -367,7 +367,10 @@ def _patch_dredd_test_server():
 
     def not_found_with_string_error(self, error='Resource not found'):
         if isinstance(error, Exception):
-            error = str(error) or error.args[0]
+            error_message = str(error)
+            if not error_message and getattr(error, 'args', None):
+                error_message = error.args[0]
+            error = error_message or 'Resource not found'
         return original_not_found(self, error)
 
     BaseRequestHandler._not_found = not_found_with_string_error

--- a/dredd/dredd_hook.py
+++ b/dredd/dredd_hook.py
@@ -59,8 +59,17 @@ def order_and_load_api_description(transactions):
     """Load api description."""
     global api_description
 
-    # Set DELETE transactions last, keep the rest unchanged
-    transactions.sort(key=lambda x: (x['request']['method'] == 'DELETE', True))
+    def _sort_key(transaction):
+        # DELETE transactions go last so the rest of the suite has the fixture
+        # to query against. Among DELETEs we want the most-specific paths first
+        # (e.g. DELETE /series/{id}/episodes/{id} BEFORE DELETE /series/{id})
+        # so that child resources are removed before their parent — otherwise
+        # the parent delete makes subsequent child DELETEs return 404.
+        is_delete = transaction['request']['method'] == 'DELETE'
+        depth = -len(transaction['origin']['resourceName'].split('/')) if is_delete else 0
+        return (is_delete, depth)
+
+    transactions.sort(key=_sort_key)
 
     with io.open(transactions[0]['origin']['filename'], 'rb') as stream:
         api_description = yaml.safe_load(stream)
@@ -185,6 +194,203 @@ def evaluate(expression, context=None):
     return expression
 
 
+# The slug that the Dredd transactions assume already exists. POST /api/v2/series
+# only enqueues an asynchronous indexer fetch, which never resolves in CI, so we
+# seed the database (and the in-memory show list) ourselves before the web
+# server begins accepting requests.
+TEST_SERIES_INDEXER = 1  # tvdb
+TEST_SERIES_ID = 301824
+TEST_SERIES_EPISODES = ((1, 1), (1, 2))
+TEST_NOT_FOUND_SERIES_ID = 99999999
+TEST_DELETE_CONFLICT_SERIES_ID = 301825
+
+MINIMAL_JPEG = (
+    b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01'
+    b'\x00\x00\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07'
+    b'\x07\t\t\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14'
+    b'\x1d\x1a\x1f\x1e\x1d\x1a\x1c\x1c $.\' ",#\x1c\x1c(7),01444'
+    b'\x1f\'9=82<.342\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01'
+    b'\x11\x00\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01'
+    b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06'
+    b'\x07\x08\t\n\x0b\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02'
+    b'\x04\x03\x05\x05\x04\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11'
+    b'\x05\x12!1A\x06\x13Qa\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15'
+    b'R\xd1\xf0$3br\x82\t\n\x16\x17\x18\x19\x1a%&\'()*456789:CDEFG'
+    b'HIJSTUVWXYZcdefghijstuvwxyz\x83\x84\x85\x86\x87\x88\x89\x8a'
+    b'\x92\x93\x94\x95\x96\x97\x98\x99\x9a\xa2\xa3\xa4\xa5\xa6\xa7'
+    b'\xa8\xa9\xaa\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xc2\xc3\xc4'
+    b'\xc5\xc6\xc7\xc8\xc9\xca\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda'
+    b'\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xf1\xf2\xf3\xf4\xf5'
+    b'\xf6\xf7\xf8\xf9\xfa\xff\xda\x00\x08\x01\x01\x00\x00?\x00\xfb'
+    b'\xd0\xff\xd9'
+)
+
+
+def _seed_series(indexer_id, title, episodes=None, alias_title=None, seed_cache_images=False):
+    """Insert a Dredd test series fixture into the database and showList."""
+    from medusa import app, db
+    from medusa.common import SKIPPED
+    from medusa.tv.series import Series
+
+    show_dir = os.path.join(os.getcwd(), 'tvdb{0}'.format(indexer_id))
+    try:
+        os.makedirs(show_dir)
+    except OSError:
+        if not os.path.isdir(show_dir):
+            raise
+
+    main_db_con = db.DBConnection()
+
+    main_db_con.upsert('tv_shows', {
+        'show_name': title,
+        'location': show_dir,
+        'network': '',
+        'genre': '',
+        'classification': '',
+        'runtime': 30,
+        'quality': 4,
+        'airs': '',
+        'status': 'Continuing',
+        'flatten_folders': 0,
+        'paused': 0,
+        'startyear': 2017,
+        'air_by_date': 0,
+        'anime': 0,
+        'scene': 0,
+        'sports': 0,
+        'subtitles': 0,
+        'notify_list': '{}',
+        'dvdorder': 0,
+        'lang': 'en',
+        'imdb_id': '',
+        'last_update_indexer': 1,
+        'rls_ignore_words': '',
+        'rls_require_words': '',
+        'default_ep_status': SKIPPED,
+    }, {'indexer': TEST_SERIES_INDEXER, 'indexer_id': indexer_id})
+
+    main_db_con.upsert('imdb_info', {
+        'imdb_id': '',
+        'title': title,
+        'year': 2017,
+        'akas': '',
+        'runtimes': 30,
+        'genres': '',
+        'countries': '',
+        'country_codes': '',
+        'certificates': '',
+        'rating': '',
+        'votes': 0,
+        'last_update': 1,
+        'plot': '',
+    }, {'indexer': TEST_SERIES_INDEXER, 'indexer_id': indexer_id})
+
+    for season, episode in episodes or ():
+        main_db_con.upsert('tv_episodes', {
+            'indexerid': indexer_id * 100 + episode,
+            'name': 'Test Episode S{0:02d}E{1:02d}'.format(season, episode),
+            'description': '',
+            'subtitles': '',
+            'subtitles_searchcount': 0,
+            'subtitles_lastsearch': '0001-01-01T00:00:00Z',
+            'airdate': 736000,
+            'hasnfo': 0,
+            'hastbn': 0,
+            'status': SKIPPED,
+            'location': '',
+            'file_size': 0,
+            'release_name': '',
+            'is_proper': 0,
+            'absolute_number': episode,
+            'version': 0,
+            'release_group': '',
+        }, {
+            'indexer': TEST_SERIES_INDEXER,
+            'showid': indexer_id,
+            'season': season,
+            'episode': episode,
+        })
+
+    if alias_title is not None:
+        main_db_con.action(
+            'DELETE FROM scene_exceptions WHERE indexer = ? AND series_id = ?',
+            [TEST_SERIES_INDEXER, indexer_id],
+        )
+        main_db_con.action(
+            'INSERT INTO scene_exceptions '
+            '(indexer, series_id, title, season, custom) VALUES (?, ?, ?, ?, ?)',
+            [TEST_SERIES_INDEXER, indexer_id, alias_title, -1, 1],
+        )
+
+    if seed_cache_images:
+        cache_image_dir = os.path.join(app.CACHE_DIR, 'images', 'tvdb')
+        try:
+            os.makedirs(cache_image_dir)
+        except OSError:
+            if not os.path.isdir(cache_image_dir):
+                raise
+        for kind in ('banner', 'poster'):
+            image_path = os.path.join(cache_image_dir, '{0}.{1}.jpg'.format(indexer_id, kind))
+            if not os.path.isfile(image_path):
+                with open(image_path, 'wb') as fh:
+                    fh.write(MINIMAL_JPEG)
+
+    series_obj = Series(TEST_SERIES_INDEXER, indexer_id)
+    if not Series.find_by_identifier(series_obj.identifier):
+        app.showList.append(series_obj)
+    print('Seeded test fixture tvdb{0} at {1}'.format(indexer_id, show_dir))
+
+
+def _seed_test_data():
+    """Insert the Dredd API contract test fixtures."""
+    _seed_series(
+        TEST_SERIES_ID,
+        'Dredd Test Show',
+        episodes=TEST_SERIES_EPISODES,
+        alias_title='Dredd Test Alias',
+        seed_cache_images=True,
+    )
+    _seed_series(
+        TEST_DELETE_CONFLICT_SERIES_ID,
+        'Dredd Delete Conflict Show',
+        seed_cache_images=True,
+    )
+
+
+def _patch_dredd_test_server():
+    """Monkeypatch Medusa for deterministic Dredd contract tests only."""
+    from medusa.queues.show_queue import ShowQueue
+    from medusa.server.api.v2.base import BaseRequestHandler
+    from medusa.tv.series import SaveSeriesException, Series
+
+    original_not_found = BaseRequestHandler._not_found
+
+    def not_found_with_string_error(self, error='Resource not found'):
+        if isinstance(error, Exception):
+            error = str(error) or error.args[0]
+        return original_not_found(self, error)
+
+    BaseRequestHandler._not_found = not_found_with_string_error
+
+    original_add_show = ShowQueue.addShow
+
+    def add_show_with_dredd_not_found(self, indexer, indexer_id, show_dir, **options):
+        if int(indexer_id) == TEST_NOT_FOUND_SERIES_ID:
+            raise SaveSeriesException('Series not found in the indexer')
+        return original_add_show(self, indexer, indexer_id, show_dir, **options)
+
+    ShowQueue.addShow = add_show_with_dredd_not_found
+
+    original_delete = Series.delete
+
+    def delete_with_dredd_conflict(self, remove_files=False):
+        if self.series_id == TEST_DELETE_CONFLICT_SERIES_ID:
+            return False
+        return original_delete(self, remove_files)
+
+    Series.delete = delete_with_dredd_conflict
+
+
 def start():
     """Start application."""
     import shutil
@@ -211,6 +417,26 @@ def start():
     sys.path.insert(1, root_dir)
 
     from medusa.__main__ import Application
+
+    # Hook into load_shows_from_db so the fixture is in place before the web
+    # server starts accepting requests; otherwise dependent transactions race
+    # against the seed and fail with "Series not found".
+    original_load_shows_from_db = Application.load_shows_from_db
+
+    def load_shows_from_db_with_seed():
+        original_load_shows_from_db()
+        try:
+            _seed_test_data()
+        except Exception as error:  # pragma: no cover - fail fast on required seed errors
+            import traceback
+            print('Failed to seed test data: {0!r}'.format(error))
+            print(traceback.format_exc())
+            raise
+
+    Application.load_shows_from_db = staticmethod(load_shows_from_db_with_seed)
+
+    _patch_dredd_test_server()
+
     application = Application()
     application.start(args)
 

--- a/medusa/server/api/v2/series.py
+++ b/medusa/server/api/v2/series.py
@@ -121,7 +121,7 @@ class SeriesHandler(BaseRequestHandler):
         except SaveSeriesException as error:
             return self._not_found(error)
 
-        return self._created(data=queue_item_obj.to_json)
+        return self._created(data=queue_item_obj.to_json, identifier=identifier.slug)
 
     def patch(self, series_slug, path_param=None):
         """Patch series."""


### PR DESCRIPTION
## Summary
- Restore Dredd API contract coverage without disabling or removing existing response cases
- Seed deterministic Dredd-only fixtures in `dredd_hook.py` (tvdb301824, tvdb301825, POST 404 via 99999999)
- Fix OpenAPI description issues and POST /series 201 Location header

## Scope
- `dredd/api-description.yml`
- `dredd/dredd_hook.py`
- `medusa/server/api/v2/series.py`

## Validation
- Local: `yarn test-api` — 91 passing, 0 failing, 14 skipped (pre-existing x-disabled on develop)
- No new `x-disabled` added
- No workflow changes

## Risk
Low — Dredd test harness and one-line API response header fix only.

## Rollback
Revert the single commit.

## Next step
After fork checks are green, force-push this commit to upstream draft PR #12215 (`fix-dredd-api-test-fixtures`).