### PR TITLE
fix: match non-standard manual search releases by episode title

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -15,6 +15,8 @@ from os.path import join
 
 from dateutil import parser, tz
 
+import guessit
+
 from medusa import (
     app,
     config,
@@ -44,6 +46,12 @@ from medusa.name_parser.parser import (
     NameParser,
 )
 from medusa.search import FORCED_SEARCH, PROPER_SEARCH
+from medusa.search.release_matcher import (
+    ReleaseMatcher,
+    expected_release_numbering,
+    extract_strong_numbering,
+    has_explicit_non_video_extension,
+)
 from medusa.session.core import ProviderSession
 from medusa.show.show import Show
 
@@ -245,6 +253,131 @@ class GenericProvider(object):
         """
         return self.cache.find_episodes(episodes)
 
+    @staticmethod
+    def _use_contextual_matching(manual_search, episodes, search_mode, manual_search_type):
+        return (
+            manual_search
+            and len(episodes) == 1
+            and search_mode == 'eponly'
+            and manual_search_type == 'episode'
+        )
+
+    @staticmethod
+    def _apply_parsed_result_to_search_result(search_result, parsed_result):
+        search_result.parsed_result = parsed_result
+        search_result.series = parsed_result.series
+        search_result.quality = parsed_result.quality
+        search_result.release_group = parsed_result.release_group
+        search_result.version = parsed_result.version
+        search_result.actual_season = parsed_result.season_number
+        search_result.actual_episodes = parsed_result.episode_numbers
+
+    @staticmethod
+    def _parsed_result_matches_series(parsed_result, series):
+        return (
+            parsed_result.series
+            and parsed_result.series.indexer == series.indexer
+            and parsed_result.series.series_id == series.series_id
+        )
+
+    @staticmethod
+    def _build_minimal_parse_result(release_name, series, parse_method):
+        guess = guessit.guessit(
+            release_name,
+            dict(show_type=parse_method)
+        )
+        parser = NameParser(
+            series=series,
+            parse_method=parse_method,
+        )
+        result = parser.to_parse_result(release_name, guess)
+        result.series = series
+        return result
+
+    def _apply_contextual_manual_parse(self, search_result, series, target_episode, contextual_matcher):
+        """Parse and match a release for a single-episode manual search."""
+        parse_method = ('normal', 'anime')[series.is_anime]
+        release_name = search_result.name
+
+        if has_explicit_non_video_extension(release_name):
+            log.debug(
+                'Rejected release because the filename extension is not a supported video type: {release_name}',
+                {'release_name': release_name}
+            )
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        parsed_result = None
+        strict_succeeded = False
+        try:
+            parsed_result = NameParser(parse_method=parse_method).parse(
+                release_name,
+                cache_result=False,
+                use_cache=False,
+            )
+            strict_succeeded = True
+        except (InvalidNameException, InvalidShowException) as error:
+            log.debug(
+                'Strict release parsing failed: {release_name}, with error: {error}',
+                {'release_name': release_name, 'error': error}
+            )
+
+        reliable = extract_strong_numbering(release_name)
+        if strict_succeeded and reliable:
+            if not self._parsed_result_matches_series(parsed_result, series):
+                log.debug(
+                    'Rejected release because strict parsing matched a different series: {release_name}',
+                    {'release_name': release_name}
+                )
+                search_result.add_cache_entry = False
+                search_result.result_wanted = False
+                return False
+
+            strong_season, strong_episodes = reliable
+            expected_season, expected_episode = expected_release_numbering(series, target_episode)
+            if strong_season == expected_season and expected_episode in strong_episodes:
+                self._apply_parsed_result_to_search_result(search_result, parsed_result)
+                return True
+
+            log.debug(
+                'Rejected release because explicit numbering conflicts with the requested episode: {release_name}',
+                {'release_name': release_name}
+            )
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        advisory_parsed = None
+        try:
+            advisory_parsed = NameParser(
+                series=series,
+                parse_method=parse_method,
+            ).parse(
+                release_name,
+                cache_result=False,
+                use_cache=False,
+            )
+        except (InvalidNameException, InvalidShowException):
+            advisory_parsed = self._build_minimal_parse_result(
+                release_name,
+                series,
+                parse_method,
+            )
+
+        match = contextual_matcher.match(release_name, advisory_parsed)
+
+        if not match.matched:
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        advisory_parsed.series = series
+        advisory_parsed.season_number = match.season
+        advisory_parsed.episode_numbers = match.episodes
+        self._apply_parsed_result_to_search_result(search_result, advisory_parsed)
+        return True
+
     def find_search_results(self, series, episodes, search_mode, forced_search=False, download_current_quality=False,
                             manual_search=False, manual_search_type='episode'):
         """
@@ -293,6 +426,15 @@ class GenericProvider(object):
         # sort qualities in descending order
         results.sort(key=operator.attrgetter('quality'), reverse=True)
 
+        use_contextual_matching = self._use_contextual_matching(
+            manual_search, episodes, search_mode, manual_search_type
+        )
+        contextual_matcher = (
+            ReleaseMatcher(series, [episodes[0]])
+            if use_contextual_matching
+            else None
+        )
+
         # Move through each item and parse with NameParser()
         for search_result in results:
 
@@ -301,25 +443,25 @@ class GenericProvider(object):
             search_result.download_current_quality = download_current_quality
             search_result.result_wanted = True
 
-            try:
-                search_result.parsed_result = NameParser(
-                    parse_method=('normal', 'anime')[series.is_anime]).parse(
-                        search_result.name)
-            except (InvalidNameException, InvalidShowException) as error:
-                log.debug('Error during parsing of release name: {release_name}, with error: {error}',
-                          {'release_name': search_result.name, 'error': error})
-                search_result.add_cache_entry = False
-                search_result.result_wanted = False
-                continue
+            if use_contextual_matching:
+                if not self._apply_contextual_manual_parse(
+                        search_result, series, episodes[0], contextual_matcher):
+                    continue
+            else:
+                try:
+                    search_result.parsed_result = NameParser(
+                        parse_method=('normal', 'anime')[series.is_anime]
+                    ).parse(search_result.name)
+                except (InvalidNameException, InvalidShowException) as error:
+                    log.debug(
+                        'Error during parsing of release name: {release_name}, with error: {error}',
+                        {'release_name': search_result.name, 'error': error}
+                    )
+                    search_result.add_cache_entry = False
+                    search_result.result_wanted = False
+                    continue
 
-            # I don't know why i'm doing this. Maybe remove it later on all together, now i've added the parsed_result
-            # to the search_result.
-            search_result.series = search_result.parsed_result.series
-            search_result.quality = search_result.parsed_result.quality
-            search_result.release_group = search_result.parsed_result.release_group
-            search_result.version = search_result.parsed_result.version
-            search_result.actual_season = search_result.parsed_result.season_number
-            search_result.actual_episodes = search_result.parsed_result.episode_numbers
+                self._apply_parsed_result_to_search_result(search_result, search_result.parsed_result)
 
             if not manual_search:
                 if not (search_result.series.air_by_date or search_result.series.sports):

--- a/medusa/search/release_matcher.py
+++ b/medusa/search/release_matcher.py
@@ -1,0 +1,303 @@
+# coding=utf-8
+"""Contextual release matching for manual episode search."""
+
+from __future__ import unicode_literals
+
+import logging
+import os
+import re
+import unicodedata
+
+from medusa import scene_exceptions
+from medusa.logger.adapters.style import BraceAdapter
+
+from six import text_type
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
+
+MIN_EPISODE_TITLE_LENGTH = 3
+
+STRONG_EPISODE_PATTERNS = [
+    re.compile(
+        r'\bS(?P<season>\d{1,2})[ ._-]*E(?P<episode>\d{1,3})\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\b(?P<season>\d{1,2})x(?P<episode>\d{1,3})\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\bseason[ ._-]*(?P<season>\d+).*?episode[ ._-]*(?P<episode>\d+)\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\bsaison[ ._-]*(?P<season>\d+).*?episode[ ._-]*(?P<episode>\d+)\b',
+        re.IGNORECASE,
+    ),
+]
+
+SEASON_PACK_PATTERNS = [
+    re.compile(r'\bs(?P<season>\d{1,2})[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bseason[ ._-]*(?P<season>\d+)[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bsaison[ ._-]*(?P<season>\d+)[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bseason[ ._-]*pack\b', re.IGNORECASE),
+]
+
+NON_VIDEO_EXTENSIONS = {
+    '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp',
+    '.nfo', '.sfv', '.txt', '.url', '.exe', '.com', '.bat',
+    '.srt', '.sub', '.idx', '.zip', '.7z',
+}
+
+
+class ReleaseMatch(object):
+    """Result of contextual release matching."""
+
+    __slots__ = ('matched', 'season', 'episodes', 'method', 'reason')
+
+    def __init__(self, matched=False, season=None, episodes=None, method=None, reason=None):
+        self.matched = matched
+        self.season = season
+        self.episodes = episodes or []
+        self.method = method
+        self.reason = reason
+
+
+def normalize_release_text(text):
+    """Normalize text for token-sequence comparison."""
+    if not text:
+        return ''
+
+    text = unicodedata.normalize('NFKD', text_type(text))
+    text = ''.join(ch for ch in text if not unicodedata.combining(ch))
+    text = text.replace("'", ' ').replace('\u2019', ' ').replace('`', ' ')
+    text = text.casefold()
+    text = re.sub(r'[\W_]+', ' ', text, flags=re.UNICODE)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+def normalize_to_tokens(text):
+    """Return normalized whitespace-delimited tokens."""
+    normalized = normalize_release_text(text)
+    if not normalized:
+        return []
+    return normalized.split(' ')
+
+
+def tokens_contain_sequence(haystack_tokens, needle_tokens):
+    """Return True when needle_tokens appear as a contiguous token subsequence."""
+    if not needle_tokens:
+        return False
+
+    if len(needle_tokens) > len(haystack_tokens):
+        return False
+
+    width = len(needle_tokens)
+    for index in range(len(haystack_tokens) - width + 1):
+        if haystack_tokens[index:index + width] == needle_tokens:
+            return True
+    return False
+
+
+def extract_strong_numbering(release_name):
+    """Extract season and episode from reliable TV numbering patterns."""
+    for pattern in STRONG_EPISODE_PATTERNS:
+        match = pattern.search(release_name)
+        if match:
+            return int(match.group('season')), [int(match.group('episode'))]
+    return None
+
+
+def is_explicit_season_pack(release_name):
+    """Return True when the release name explicitly indicates a season pack."""
+    return any(pattern.search(release_name) for pattern in SEASON_PACK_PATTERNS)
+
+
+def has_explicit_non_video_extension(release_name):
+    """Return True when the release name ends with a known non-video extension."""
+    _, extension = os.path.splitext(release_name.lower().strip())
+    return extension in NON_VIDEO_EXTENSIONS
+
+
+def guessit_episode_numbers(parsed_result):
+    if not parsed_result:
+        return []
+
+    episodes = parsed_result.episode_numbers or []
+    if episodes:
+        return list(episodes)
+
+    guess = getattr(parsed_result, 'guess', None) or {}
+    return list(guess.get('episode') or [])
+
+
+def expected_release_numbering(series, target_episode):
+    """Return the season and episode numbers expected in release names."""
+    if series.is_scene and target_episode.scene_episode:
+        return target_episode.scene_season, target_episode.scene_episode
+    return target_episode.season, target_episode.episode
+
+
+def _series_candidate_names(series, target_episode):
+    names = {series.name}
+    try:
+        for title_exception in scene_exceptions.get_season_scene_exceptions(series, -1):
+            names.add(title_exception.title)
+        for title_exception in scene_exceptions.get_season_scene_exceptions(series, target_episode.season):
+            names.add(title_exception.title)
+    except (AttributeError, TypeError):
+        pass
+    return names
+
+
+def _duplicate_episode_titles(series, normalized_title, target_episode):
+    """Return episodes sharing the same normalized title as the target."""
+    duplicates = []
+    try:
+        all_episodes = series.get_all_episodes()
+    except (AttributeError, TypeError):
+        return duplicates
+
+    for episode in all_episodes:
+        if normalize_release_text(episode.name) != normalized_title:
+            continue
+        if episode.season == target_episode.season and episode.episode == target_episode.episode:
+            continue
+        duplicates.append(episode)
+    return duplicates
+
+
+class ReleaseMatcher(object):
+    """Match a provider release to a manually requested episode."""
+
+    def __init__(self, series, requested_episodes):
+        self.series = series
+        self.requested_episodes = requested_episodes or []
+        self.target_episode = self.requested_episodes[0] if len(self.requested_episodes) == 1 else None
+        self._series_token_candidates = []
+        self._target_has_ambiguous_title = False
+        if self.target_episode is not None:
+            for name in _series_candidate_names(series, self.target_episode):
+                tokens = normalize_to_tokens(name)
+                if tokens:
+                    self._series_token_candidates.append(tokens)
+
+            normalized_title = normalize_release_text(self.target_episode.name)
+            if len(normalized_title) >= MIN_EPISODE_TITLE_LENGTH:
+                self._target_has_ambiguous_title = bool(
+                    _duplicate_episode_titles(series, normalized_title, self.target_episode)
+                )
+
+    def matches_series(self, release_name):
+        """Return True when a known series alias appears as a token subsequence."""
+        release_tokens = normalize_to_tokens(release_name)
+        if not release_tokens:
+            return False
+
+        for candidate_tokens in self._series_token_candidates:
+            if tokens_contain_sequence(release_tokens, candidate_tokens):
+                return True
+        return False
+
+    def match(self, release_name, parsed_result=None):
+        """Decide whether the release matches the requested episode."""
+        if self.target_episode is None:
+            return ReleaseMatch(matched=False, reason='implicit_season_pack')
+
+        if has_explicit_non_video_extension(release_name):
+            log.debug(
+                'Rejected release because the filename extension is not a supported video type: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='non_video_extension')
+
+        if is_explicit_season_pack(release_name):
+            log.debug(
+                'Rejected unnumbered release instead of treating it as a season pack: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='implicit_season_pack')
+
+        if not self.matches_series(release_name):
+            log.debug(
+                'Rejected release because the series name was not found: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='series_not_found')
+
+        target = self.target_episode
+        strong = extract_strong_numbering(release_name)
+        guess_episodes = guessit_episode_numbers(parsed_result)
+        normalized_title = normalize_release_text(target.name)
+        title_tokens = normalize_to_tokens(target.name)
+        release_tokens = normalize_to_tokens(release_name)
+        title_present = (
+            len(normalized_title) >= MIN_EPISODE_TITLE_LENGTH
+            and tokens_contain_sequence(release_tokens, title_tokens)
+        )
+
+        if strong:
+            strong_season, strong_episodes = strong
+            strong_episode = strong_episodes[0]
+            expected_season, expected_episode = expected_release_numbering(self.series, target)
+            if strong_season == expected_season and strong_episode == expected_episode:
+                log.info(
+                    'Matched release using explicit season and episode numbering: {release_name}',
+                    {'release_name': release_name}
+                )
+                return ReleaseMatch(
+                    matched=True,
+                    season=target.season,
+                    episodes=[target.episode],
+                    method='explicit_numbering',
+                    reason='explicit_numbering',
+                )
+
+            log.debug(
+                'Rejected release because explicit numbering conflicts with the requested episode: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='explicit_number_conflict')
+
+        if not title_present:
+            if guess_episodes:
+                log.debug(
+                    'Rejected release because weak numbering was found without a title match: {release_name}',
+                    {'release_name': release_name}
+                )
+            else:
+                log.debug(
+                    'Rejected release because no unique episode-title match was found: {release_name}',
+                    {'release_name': release_name}
+                )
+            return ReleaseMatch(matched=False, reason='episode_title_not_found')
+
+        if self._target_has_ambiguous_title:
+            log.debug(
+                'Rejected release because the episode title is ambiguous: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='ambiguous_episode_title')
+
+        if guess_episodes:
+            log.debug(
+                'Ignored weak episode number extracted from release suffix: {release_name}',
+                {'release_name': release_name}
+            )
+            method = 'weak_number_ignored'
+        else:
+            method = 'episode_title'
+
+        log.info(
+            'Matched release using the requested episode title: {release_name}',
+            {'release_name': release_name}
+        )
+        return ReleaseMatch(
+            matched=True,
+            season=target.season,
+            episodes=[target.episode],
+            method=method,
+            reason=method,
+        )

--- a/tests/search/__init__.py
+++ b/tests/search/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/tests/search/test_release_matcher.py
+++ b/tests/search/test_release_matcher.py
@@ -1,0 +1,512 @@
+# coding=utf-8
+"""Tests for contextual release matching."""
+
+from __future__ import unicode_literals
+
+from mock.mock import Mock, patch
+
+import pytest
+
+from medusa.name_parser.parser import InvalidNameException
+from medusa.providers.generic_provider import GenericProvider
+from medusa.search.release_matcher import (
+    ReleaseMatch,
+    ReleaseMatcher,
+    extract_strong_numbering,
+    has_explicit_non_video_extension,
+    is_explicit_season_pack,
+    normalize_release_text,
+    normalize_to_tokens,
+    tokens_contain_sequence,
+)
+
+
+SHOW_NAME = 'Alpha Chronicle'
+OTHER_SHOW = 'Beta Chronicle'
+EPISODE_TITLE = 'First Contact'
+OTHER_EPISODE_TITLE = 'Second Wave'
+
+
+def _episode(season, episode, name):
+    ep = Mock()
+    ep.season = season
+    ep.episode = episode
+    ep.name = name
+    return ep
+
+
+def _series(name, episodes, **kwargs):
+    series = Mock()
+    series.name = name
+    series.is_anime = kwargs.get('is_anime', False)
+    series.is_scene = kwargs.get('is_scene', False)
+    series.indexer = kwargs.get('indexer', 1)
+    series.series_id = kwargs.get('series_id', 100)
+    series.get_all_episodes.return_value = episodes
+    return series
+
+
+def _scene_episode(season, episode, scene_season, scene_episode, name):
+    ep = _episode(season, episode, name)
+    ep.scene_season = scene_season
+    ep.scene_episode = scene_episode
+    return ep
+
+
+@pytest.fixture(autouse=True)
+def mock_scene_exceptions():
+    with patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[]):
+        yield
+
+
+def _matcher(series, episodes):
+    return ReleaseMatcher(series, episodes)
+
+
+@pytest.fixture
+def alpha_series():
+    return _series(SHOW_NAME, [
+        _episode(1, 1, EPISODE_TITLE),
+        _episode(1, 2, OTHER_EPISODE_TITLE),
+    ])
+
+
+@pytest.fixture
+def alpha_matcher(alpha_series):
+    return _matcher(alpha_series, [_episode(1, 1, EPISODE_TITLE)])
+
+
+def test_normalize_and_token_sequence():
+    assert normalize_release_text("Alpha Chronicle") == 'alpha chronicle'
+    assert normalize_to_tokens('[Uploader] Alpha.Chronicle') == ['uploader', 'alpha', 'chronicle']
+    assert tokens_contain_sequence(['alpha', 'chronicle', 'first', 'contact'], ['alpha', 'chronicle']) is True
+    assert tokens_contain_sequence(['beta', 'chronicle'], ['alpha', 'chronicle']) is False
+
+
+def test_normalize_punctuation_variants():
+    assert normalize_release_text('Alpha, Chronicle') == 'alpha chronicle'
+    assert normalize_release_text('Alpha.Series') == 'alpha series'
+    assert normalize_release_text('First Contact: Part One') == 'first contact part one'
+    assert normalize_release_text('Alpha & Chronicle') == 'alpha chronicle'
+    assert normalize_to_tokens('Alpha, Chronicle') == normalize_to_tokens('Alpha.Chronicle')
+
+
+def test_extract_strong_numbering():
+    assert extract_strong_numbering('Alpha.Chronicle.S01E02.Title') == (1, [2])
+    assert extract_strong_numbering('Alpha.Chronicle.1x02.Title') == (1, [2])
+    assert extract_strong_numbering('Alpha.Chronicle.site-1--group') is None
+
+
+def test_explicit_numbering_match(alpha_matcher):
+    release = 'Alpha.Chronicle.S01E01.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'explicit_numbering'
+    assert match.episodes == [1]
+
+
+def test_explicit_numbering_without_title(alpha_matcher):
+    release = 'Alpha.Chronicle.S01E01.1080p.WEB.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'explicit_numbering'
+
+
+def test_explicit_numbering_conflict(alpha_matcher):
+    release = 'Alpha.Chronicle.S01E02.First.Contact.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'explicit_number_conflict'
+
+
+def test_title_match_without_numbering(alpha_matcher):
+    release = 'Alpha.Chronicle.-.Segment.-.First.Contact.-.suffix.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'episode_title'
+    assert match.season == 1
+    assert match.episodes == [1]
+
+
+def test_prefix_before_series_title(alpha_matcher):
+    release = '[Uploader] Alpha.Chronicle.-.First.Contact.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'episode_title'
+
+
+def test_suffix_after_episode_title(alpha_matcher):
+    release = 'Alpha.Chronicle.-.First.Contact.-.website-1--group.mkv'
+    parsed = Mock()
+    parsed.episode_numbers = [1]
+    parsed.guess = {'episode': [1]}
+    match = alpha_matcher.match(release, parsed_result=parsed)
+    assert match.matched is True
+    assert match.method == 'weak_number_ignored'
+
+
+def test_weak_number_without_title_rejected(alpha_matcher):
+    release = 'Alpha.Chronicle.-.website-1--group.mkv'
+    parsed = Mock()
+    parsed.episode_numbers = [1]
+    parsed.guess = {'episode': [1]}
+    match = alpha_matcher.match(release, parsed_result=parsed)
+    assert match.matched is False
+    assert match.reason == 'episode_title_not_found'
+
+
+def test_other_series_rejected():
+    series = _series(OTHER_SHOW, [_episode(1, 1, EPISODE_TITLE)])
+    matcher = _matcher(series, [_episode(1, 1, EPISODE_TITLE)])
+    release = 'Beta.Chronicle.-.First.Contact.mkv'
+    assert matcher.matches_series(release) is True
+    matcher = _matcher(_series(SHOW_NAME, [_episode(1, 1, EPISODE_TITLE)]), [_episode(1, 1, EPISODE_TITLE)])
+    match = matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'series_not_found'
+
+
+def test_duplicate_episode_titles_rejected():
+    episodes = [
+        _episode(1, 1, 'Shared Title'),
+        _episode(2, 1, 'Shared Title'),
+    ]
+    series = _series(SHOW_NAME, episodes)
+    matcher = _matcher(series, [episodes[0]])
+    release = 'Alpha.Chronicle.-.Shared.Title.mkv'
+    match = matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'ambiguous_episode_title'
+
+
+def test_short_series_title_not_matched_inside_unrelated_word():
+    series = _series('Go', [_episode(1, 1, EPISODE_TITLE)])
+    matcher = _matcher(series, [_episode(1, 1, EPISODE_TITLE)])
+    release = 'Dragon.-.First.Contact.mkv'
+    assert matcher.matches_series(release) is False
+
+
+def test_unresolved_release_not_season_pack(alpha_matcher):
+    release = 'Alpha.Chronicle.-.Unrelated.Segment.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'episode_title_not_found'
+
+
+def test_explicit_season_pack_marker_rejected_for_single_episode(alpha_matcher):
+    release = 'Alpha.Chronicle.Season.1.Complete.mkv'
+    assert is_explicit_season_pack(release) is True
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'implicit_season_pack'
+
+
+def test_non_video_extension_has_dedicated_rejection_reason(alpha_matcher):
+    match = alpha_matcher.match('Alpha Chronicle - First Contact.nfo')
+    assert match.matched is False
+    assert match.reason == 'non_video_extension'
+
+
+def test_rar_extension_is_not_rejected_as_non_video():
+    assert not has_explicit_non_video_extension('Alpha Chronicle - First Contact.rar')
+
+
+def test_multipart_rar_extension_is_not_rejected_as_non_video():
+    assert not has_explicit_non_video_extension(
+        'Alpha Chronicle - First Contact.part01.rar'
+    )
+
+
+def test_contextual_match_accepts_processable_rar_release(alpha_matcher):
+    result = alpha_matcher.match('Alpha Chronicle - First Contact.part01.rar')
+    assert result.matched is True
+    assert result.reason != 'non_video_extension'
+
+
+def test_contextual_matching_gate():
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'eponly', 'episode') is True
+    assert GenericProvider._use_contextual_matching(True, [Mock(), Mock()], 'eponly', 'episode') is False
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'sponly', 'episode') is False
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'eponly', 'season') is False
+    assert GenericProvider._use_contextual_matching(False, [Mock()], 'eponly', 'episode') is False
+
+
+def test_non_manual_path_uses_strict_parser_only():
+    provider = GenericProvider('TestProvider')
+    episode = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [episode])
+    series.air_by_date = False
+    series.sports = False
+
+    search_result = Mock()
+    search_result.name = 'Alpha.Chronicle.S01E01.mkv'
+    search_result.add_cache_entry = False
+    search_result.result_wanted = True
+    search_result.quality = 0
+    search_result.episode_number = 1
+    search_result.update_search_result = Mock()
+    search_result.add_result_to_cache = Mock(return_value=None)
+
+    parsed = Mock()
+    parsed.series = series
+    parsed.quality = 1
+    parsed.release_group = 'GROUP'
+    parsed.version = -1
+    parsed.season_number = 1
+    parsed.episode_numbers = [1]
+
+    with patch.object(provider, '_check_auth'), \
+         patch.object(provider, '_get_episode_search_strings', return_value=['Alpha Chronicle S01E01']), \
+         patch.object(provider, 'search', return_value=[Mock()]), \
+         patch.object(provider, 'get_result', return_value=search_result), \
+         patch.object(provider, '_apply_contextual_manual_parse') as contextual_parse, \
+         patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.return_value.parse.return_value = parsed
+        provider.find_search_results(
+            series,
+            [episode],
+            'eponly',
+            manual_search=False,
+            manual_search_type='episode',
+        )
+
+    contextual_parse.assert_not_called()
+    parser_cls.return_value.parse.assert_called_once_with(search_result.name)
+    assert search_result.actual_season == 1
+    assert search_result.actual_episodes == [1]
+
+
+def test_scene_numbering_explicit_match():
+    target = _scene_episode(2, 5, 1, 5, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target], is_scene=True)
+    matcher = _matcher(series, [target])
+    match = matcher.match('Alpha.Chronicle.S01E05.mkv')
+    assert match.matched is True
+    assert match.method == 'explicit_numbering'
+    assert match.season == 2
+    assert match.episodes == [5]
+
+
+def test_season_exceptions_limited_to_target_season():
+    season_five_alias = Mock(title='Season Five Alias')
+    target = _episode(1, 1, EPISODE_TITLE)
+
+    def season_exceptions(series, season):
+        if season == 5:
+            return [season_five_alias]
+        return []
+
+    with patch(
+        'medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions',
+        side_effect=season_exceptions,
+    ):
+        matcher = _matcher(_series(SHOW_NAME, [target]), [target])
+        assert matcher.matches_series('Season.Five.Alias.-.First.Contact.mkv') is False
+
+
+def test_contextual_strict_parse_disables_name_parser_cache():
+    provider = GenericProvider('TestProvider')
+    search_result = Mock()
+    search_result.name = 'Alpha.Chronicle.S01E01.mkv'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    target = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target])
+
+    parsed = Mock()
+    parsed.series = series
+    parsed.quality = 1
+    parsed.release_group = 'GROUP'
+    parsed.version = -1
+    parsed.season_number = 1
+    parsed.episode_numbers = [1]
+
+    strict_parser = Mock()
+    strict_parser.parse.return_value = parsed
+    matcher = _matcher(series, [target])
+
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.return_value = strict_parser
+        assert provider._apply_contextual_manual_parse(
+            search_result, series, target, matcher) is True
+
+    strict_parser.parse.assert_called_once_with(
+        search_result.name,
+        cache_result=False,
+        use_cache=False,
+    )
+
+
+def test_contextual_manual_parse_title_fallback():
+    provider = GenericProvider('TestProvider')
+    search_result = Mock()
+    search_result.name = 'Alpha Chronicle - First Contact - suffix.mkv'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    target = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target])
+
+    strict_parser = Mock()
+    strict_parser.parse.side_effect = InvalidNameException('strict parse failed')
+    advisory_parser = Mock()
+    advisory_parsed = Mock()
+    advisory_parsed.episode_numbers = []
+    advisory_parsed.guess = {}
+    advisory_parser.parse.return_value = advisory_parsed
+
+    matcher = _matcher(series, [target])
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.side_effect = [strict_parser, advisory_parser]
+        assert provider._apply_contextual_manual_parse(
+            search_result, series, target, matcher) is True
+
+    assert search_result.actual_season == 1
+    assert search_result.actual_episodes == [1]
+    assert search_result.result_wanted is True
+
+
+def test_contextual_manual_parse_explicit_conflict():
+    provider = GenericProvider('TestProvider')
+    search_result = Mock()
+    search_result.name = 'Alpha.Chronicle.S01E02.First.Contact.mkv'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    target = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target, _episode(1, 2, OTHER_EPISODE_TITLE)])
+
+    parsed = Mock()
+    parsed.series = series
+    parsed.quality = 1
+    parsed.release_group = 'GROUP'
+    parsed.version = -1
+    parsed.season_number = 1
+    parsed.episode_numbers = [2]
+
+    matcher = _matcher(series, [target])
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.return_value.parse.return_value = parsed
+        assert provider._apply_contextual_manual_parse(
+            search_result, series, target, matcher) is False
+
+    assert search_result.result_wanted is False
+    assert search_result.add_cache_entry is False
+
+
+def test_contextual_manual_parse_wrong_series_strict_path():
+    provider = GenericProvider('TestProvider')
+    search_result = Mock()
+    search_result.name = 'Beta.Chronicle.S01E01.mkv'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    target = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target], series_id=100)
+
+    other_series = Mock()
+    other_series.indexer = 1
+    other_series.series_id = 200
+
+    parsed = Mock()
+    parsed.series = other_series
+    parsed.quality = 1
+    parsed.release_group = 'GROUP'
+    parsed.version = -1
+    parsed.season_number = 1
+    parsed.episode_numbers = [1]
+
+    matcher = _matcher(series, [target])
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.return_value.parse.return_value = parsed
+        assert provider._apply_contextual_manual_parse(
+            search_result, series, target, matcher) is False
+
+    assert search_result.result_wanted is False
+    assert search_result.add_cache_entry is False
+
+
+def test_contextual_manual_parse_rejects_non_video_extension():
+    provider = GenericProvider('TestProvider')
+    search_result = Mock()
+    search_result.name = 'Alpha.Chronicle.-.First.Contact.nfo'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    target = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [target])
+    matcher = _matcher(series, [target])
+
+    assert provider._apply_contextual_manual_parse(
+        search_result, series, target, matcher) is False
+    assert search_result.result_wanted is False
+    assert search_result.add_cache_entry is False
+
+
+def test_build_minimal_parse_result_uses_parse_method():
+    series = _series(SHOW_NAME, [_episode(1, 1, EPISODE_TITLE)], is_anime=True)
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls, \
+         patch('medusa.providers.generic_provider.guessit.guessit', return_value={}) as guessit_mock:
+        parser_instance = parser_cls.return_value
+        parser_instance.to_parse_result.return_value = Mock()
+        GenericProvider._build_minimal_parse_result('release.mkv', series, 'anime')
+
+    guessit_mock.assert_called_once_with('release.mkv', dict(show_type='anime'))
+    parser_cls.assert_called_once_with(series=series, parse_method='anime')
+
+
+def test_find_search_results_reuses_single_contextual_matcher():
+    provider = GenericProvider('TestProvider')
+    episode = _episode(1, 1, EPISODE_TITLE)
+    series = _series(SHOW_NAME, [episode])
+    series.air_by_date = False
+    series.sports = False
+
+    search_result_one = Mock()
+    search_result_one.name = 'Alpha.Chronicle.-.First.Contact.one.mkv'
+    search_result_one.add_cache_entry = False
+    search_result_one.result_wanted = True
+    search_result_one.quality = 0
+    search_result_one.episode_number = 1
+    search_result_one.update_search_result = Mock()
+    search_result_one.add_result_to_cache = Mock(return_value=None)
+
+    search_result_two = Mock()
+    search_result_two.name = 'Alpha.Chronicle.-.First.Contact.two.mkv'
+    search_result_two.add_cache_entry = False
+    search_result_two.result_wanted = True
+    search_result_two.quality = 0
+    search_result_two.episode_number = 1
+    search_result_two.update_search_result = Mock()
+    search_result_two.add_result_to_cache = Mock(return_value=None)
+
+    match = ReleaseMatch(matched=True, season=1, episodes=[1], method='episode_title')
+    matcher_instance = Mock()
+    matcher_instance.match.return_value = match
+
+    with patch.object(provider, '_check_auth'), \
+         patch.object(provider, '_get_episode_search_strings', return_value=['Alpha Chronicle']), \
+         patch.object(provider, 'search', return_value=[Mock(), Mock()]), \
+         patch.object(provider, 'get_result', side_effect=[search_result_one, search_result_two]), \
+         patch('medusa.providers.generic_provider.ReleaseMatcher', return_value=matcher_instance) as matcher_cls, \
+         patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        strict_parser = Mock()
+        strict_parser.parse.side_effect = InvalidNameException('strict parse failed')
+        advisory_parser = Mock()
+        advisory_parsed = Mock()
+        advisory_parsed.episode_numbers = []
+        advisory_parsed.guess = {}
+        advisory_parser.parse.return_value = advisory_parsed
+        parser_cls.side_effect = [strict_parser, advisory_parser, strict_parser, advisory_parser]
+
+        provider.find_search_results(
+            series,
+            [episode],
+            'eponly',
+            manual_search=True,
+            manual_search_type='episode',
+        )
+
+    matcher_cls.assert_called_once_with(series, [episode])
+    assert matcher_instance.match.call_count == 2


### PR DESCRIPTION
## Internal validation

> This PR is used only to validate the implementation on the fork. Do not merge it into `develop`. After the final review, the branch will be squashed and submitted to `pymedusa/Medusa`.

## Problem

Manual single-episode searches can return valid provider results whose release names do not contain reliable `SxxExx` or `1x01` numbering. These names may still contain the correct series and episode titles, but strict parsing rejects them before they can be displayed.

Unrelated numeric suffixes can also be interpreted as episode numbers, which makes non-standard releases especially unreliable when handled by the strict parser alone.

## Solution

Add a contextual matcher for manual searches targeting one episode:

- keep strict parsing and reliable explicit numbering authoritative;
- use the requested series and episode title only as a guarded fallback;
- normalize punctuation, accents and separators before token matching;
- accept title-based matches only when the series and episode title are unambiguous;
- reject explicit numbering that conflicts with the requested episode;
- treat GuessIt-only numbers without a reliable numbering pattern as weak;
- support scene numbering and relevant scene aliases;
- prevent unresolved releases from becoming implicit season packs;
- reject explicit non-media filenames while allowing processable RAR releases;
- bypass the global `NameParser` cache in the contextual path to avoid cross-series contamination.

## Scope

The fallback is enabled only when all of the following are true:

- manual search;
- exactly one requested episode;
- `eponly` search mode;
- manual search type `episode`.

The following paths remain unchanged:

- automatic, daily and backlog searches;
- proper searches;
- season searches;
- post-processing and library scanning;
- global `get_show()` and `NameParser._parse_series()` behavior.

## Safety rules

- Reliable explicit numbering wins over title matching.
- Conflicting explicit numbering is rejected.
- Another series with the same episode title is rejected.
- Duplicate episode titles are rejected as ambiguous.
- Matching uses normalized contiguous token sequences, not fuzzy similarity.
- Unnumbered results are never treated as season packs without an explicit pack marker.

## Validation

Focused tests cover normalization, reliable and weak numbering, scene numbering, aliases, ambiguous titles, non-media extensions, RAR releases, parser-cache isolation, provider integration and non-manual-path preservation.

```bash
python -m pytest \
  tests/search/test_release_matcher.py \
  tests/providers/test_generic_provider.py \
  tests/name_parser/test_parse_series.py \
  -q

python -m compileall \
  medusa/search/release_matcher.py \
  medusa/providers/generic_provider.py

git diff --check
```

Runtime validation confirmed that non-standard manual-search results are displayed and assigned to the requested episode, while weak numeric suffixes are ignored.

Related to pymedusa/Medusa#12219.