### PR TITLE
fix: select qBittorrent state endpoints by Web API version

### DIFF
--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -190,6 +190,16 @@ class GenericClient(object):
         """
         return True
 
+    def _set_torrent_state(self, result):
+        """Apply the client-specific initial torrent state.
+
+        :param result:
+        :type result: medusa.classes.SearchResult
+        :return:
+        :rtype: bool
+        """
+        return self._set_torrent_pause(result)
+
     @staticmethod
     def _get_info_hash(result):
         if result.url.startswith('magnet:'):
@@ -248,10 +258,10 @@ class GenericClient(object):
             log.warning('{name}: Unable to send Torrent', {'name': self.name})
             return False
 
-        if self._set_torrent_pause(result) or self._set_torrent_stop(result):
-            log.info('{name}: Able to set the pause/stop for Torrent', {'name': self.name})
+        if self._set_torrent_state(result):
+            log.info('{name}: Able to set the initial torrent state', {'name': self.name})
         else:
-            log.error('{name}: Unable to set the pause/stop for Torrent', {'name': self.name})
+            log.error('{name}: Unable to set the initial torrent state', {'name': self.name})
 
         if not self._set_torrent_label(result):
             log.error('{name}: Unable to set the label for Torrent', {'name': self.name})

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -23,6 +23,9 @@ import ttl_cache
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
 
+# qBittorrent 5.0 reports Web API 2.11.2 and replaces pause/resume with stop/start.
+QBITTORRENT_START_STOP_API = (2, 11, 2)
+
 
 class APIUnavailableError(Exception):
     """Raised when the API version is not available."""
@@ -242,14 +245,40 @@ class QBittorrentAPI(GenericClient):
 
         return ok
 
-    def _set_torrent_pause(self, result):
-        return self.pause_torrent(result.hash, state='pause' if app.TORRENT_PAUSED else 'resume')
+    def _uses_start_stop_api(self):
+        """Return whether the connected qBittorrent Web API uses start/stop endpoints."""
+        return bool(self.api) and self.api >= QBITTORRENT_START_STOP_API
 
-    def _set_torrent_stop(self, result):
-        return self.stop_torrent(result.hash, state='stop' if app.TORRENT_STOPPED else 'start')
+    def _torrent_state_endpoint(self, active):
+        """Return the torrent-state endpoint for the reported Web API version."""
+        if self._uses_start_stop_api():
+            return 'start' if active else 'stop'
+        return 'resume' if active else 'pause'
+
+    def _normalize_torrent_state(self, state):
+        """Translate state names to the API generation reported by the client."""
+        if self._uses_start_stop_api():
+            if state == 'resume':
+                return 'start'
+            if state == 'pause':
+                return 'stop'
+            return state
+
+        if state == 'start':
+            return 'resume'
+        if state == 'stop':
+            return 'pause'
+        return state
+
+    def _set_torrent_state(self, result):
+        """Set torrent active or suspended state using a single API request."""
+        suspended = app.TORRENT_PAUSED or app.TORRENT_STOPPED
+        state = self._torrent_state_endpoint(active=not suspended)
+        return self.pause_torrent(result.hash, state=state)
 
     def pause_torrent(self, info_hash, state='pause'):
-        """Pause torrent."""
+        """Pause or resume/start torrent depending on the connected Web API version."""
+        state = self._normalize_torrent_state(state)
         command = 'api/v2/torrents' if self.api >= (2, 0, 0) else 'command'
         hashes_key = 'hashes' if self.api >= (1, 18, 0) else 'hash'
         self.url = urljoin(self.host, '{command}/{state}'.format(command=command, state=state))
@@ -259,14 +288,8 @@ class QBittorrentAPI(GenericClient):
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
     def stop_torrent(self, info_hash, state='stop'):
-        """Stop torrent."""
-        command = 'api/v2/torrents' if self.api >= (2, 0, 0) else 'command'
-        hashes_key = 'hashes' if self.api >= (1, 18, 0) else 'hash'
-        self.url = urljoin(self.host, '{command}/{state}'.format(command=command, state=state))
-        data = {
-            hashes_key: info_hash.lower()
-        }
-        return self._request(method='post', data=data, cookies=self.session.cookies)
+        """Stop or start torrent depending on the connected Web API version."""
+        return self.pause_torrent(info_hash, state=state)
 
     def _remove(self, info_hash, from_disk=False):
         """Remove torrent from client using given info_hash.
@@ -414,11 +437,9 @@ class QBittorrentAPI(GenericClient):
             client_status.set_status_string('Downloading')
 
         # Might want to separate these into a PausedDl and PausedUl in future.
-        if torrent['state'] in ('pausedDL', 'stalledDL'):
+        # qBittorrent 5.0+ reports stoppedDL instead of pausedDL.
+        if torrent['state'] in ('pausedDL', 'stalledDL', 'stoppedDL'):
             client_status.set_status_string('Paused')
-
-        if torrent['state'] in ('stoppdDL'):
-            client_status.set_status_string('Stopped')
 
         if torrent['state'] == 'error':
             client_status.set_status_string('Failed')

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -1,11 +1,40 @@
 # coding=utf-8
 
-import json
-import os
-
 from medusa.clients.torrent.qbittorrent import QBittorrentAPI
 
 import pytest
+
+
+class SearchResultStub(object):
+    """Minimal search result stub for torrent client tests."""
+
+    hash = 'aabbccdd'
+
+
+def _state_requests(requests_mock):
+    """Return POST requests made to torrent state endpoints."""
+    return [
+        request for request in requests_mock.request_history
+        if request.method == 'POST' and '/api/v2/torrents/' in request.url
+        and not request.url.endswith('/add')
+    ]
+
+
+def _mock_qbittorrent_auth(requests_mock, api_text='2.15.1'):
+    """Mock auth and Web API version lookups performed during client construction."""
+    requests_mock.post('http://localhost/api/v2/auth/login', text='Ok.', status_code=200)
+    requests_mock.get('http://localhost/api/v2/app/webapiVersion', text=api_text)
+
+
+def _make_qbittorrent_client(api=(2, 15, 1)):
+    """Return a QBittorrentAPI instance without triggering constructor HTTP calls."""
+    client = QBittorrentAPI.__new__(QBittorrentAPI)
+    client.name = 'qBittorrent'
+    client.host = 'http://localhost/'
+    client.api = api
+    client.auth = True
+    client.session = None
+    return client
 
 
 def test_auth_v2_empty_204_response_is_success(requests_mock):
@@ -130,24 +159,178 @@ def test_add_torrent_uri_accepts_legacy_ok_response(requests_mock, monkeypatch):
     assert actual is True
 
 
-@pytest.mark.parametrize('p', [
-    {  # p0
-        'method': 'properties',
-        'uri': 'http://localhost/api/v2/torrents/properties',
-        'expected': True
-    },
+@pytest.mark.parametrize('api_version,torrent_paused,torrent_stopped,expected_endpoint', [
+    ((2, 10, 0), False, False, 'resume'),
+    ((2, 10, 0), True, False, 'pause'),
+    ((2, 10, 0), False, True, 'pause'),
+    ((2, 11, 2), False, False, 'start'),
+    ((2, 15, 1), True, False, 'stop'),
+    ((2, 15, 1), False, True, 'stop'),
 ])
-def test_torrent_completed(p, response_mock):
+def test_set_torrent_state_uses_single_endpoint_for_api_version(
+        api_version, torrent_paused, torrent_stopped, expected_endpoint, requests_mock, monkeypatch):
     # Given
-    expected = p['expected']
+    monkeypatch.setattr('medusa.app.TORRENT_PAUSED', torrent_paused)
+    monkeypatch.setattr('medusa.app.TORRENT_STOPPED', torrent_stopped)
+    _mock_qbittorrent_auth(requests_mock, api_text='.'.join(str(part) for part in api_version))
+
+    for endpoint in ('resume', 'pause', 'start', 'stop'):
+        requests_mock.post(
+            'http://localhost/api/v2/torrents/{0}'.format(endpoint),
+            text='',
+            status_code=200,
+        )
+
+    client = QBittorrentAPI(host='http://localhost')
+    client.api = api_version
+    client.auth = True
+
+    # When
+    actual = client._set_torrent_state(SearchResultStub())
+
+    # Then
+    assert actual is True
+    state_requests = _state_requests(requests_mock)
+    assert len(state_requests) == 1
+    assert state_requests[0].url.endswith('/api/v2/torrents/{0}'.format(expected_endpoint))
+
+
+def test_set_torrent_state_new_api_does_not_call_legacy_endpoints(requests_mock, monkeypatch):
+    # Given
+    monkeypatch.setattr('medusa.app.TORRENT_PAUSED', False)
+    monkeypatch.setattr('medusa.app.TORRENT_STOPPED', False)
+    _mock_qbittorrent_auth(requests_mock, api_text='2.15.1')
+    requests_mock.post('http://localhost/api/v2/torrents/start', text='', status_code=200)
+
+    client = QBittorrentAPI(host='http://localhost')
+    client.api = (2, 15, 1)
+    client.auth = True
+
+    # When
+    client._set_torrent_state(SearchResultStub())
+
+    # Then
+    state_requests = _state_requests(requests_mock)
+    assert len(state_requests) == 1
+    assert state_requests[0].url.endswith('/torrents/start')
+    assert not any('/torrents/resume' in request.url for request in requests_mock.request_history)
+    assert not any('/torrents/pause' in request.url for request in requests_mock.request_history)
+
+
+def test_set_torrent_state_old_api_does_not_call_start_stop_endpoints(requests_mock, monkeypatch):
+    # Given
+    monkeypatch.setattr('medusa.app.TORRENT_PAUSED', False)
+    monkeypatch.setattr('medusa.app.TORRENT_STOPPED', False)
+    _mock_qbittorrent_auth(requests_mock, api_text='2.10.0')
+    requests_mock.post('http://localhost/api/v2/torrents/resume', text='', status_code=200)
+
+    client = QBittorrentAPI(host='http://localhost')
+    client.api = (2, 10, 0)
+    client.auth = True
+
+    # When
+    client._set_torrent_state(SearchResultStub())
+
+    # Then
+    state_requests = _state_requests(requests_mock)
+    assert len(state_requests) == 1
+    assert state_requests[0].url.endswith('/torrents/resume')
+    assert not any('/torrents/start' in request.url for request in requests_mock.request_history)
+    assert not any('/torrents/stop' in request.url for request in requests_mock.request_history)
+
+
+@pytest.mark.parametrize('qbit_state,expected_status', [
+    ('downloading', 'Downloading'),
+    ('metaDL', 'Downloading'),
+    ('stoppedDL', 'Paused'),
+    ('pausedDL', 'Paused'),
+    ('stalledUP', 'Completed'),
+    ('stoppedUP', 'Completed'),
+    ('error', 'Failed'),
+])
+def test_get_status_maps_qbittorrent_states(qbit_state, expected_status):
+    # Given
+    info_hash = 'aabbccdd'
+    torrent = {
+        'hash': info_hash,
+        'state': qbit_state,
+        'ratio': 0,
+        'downloaded': 100,
+        'size': 1000,
+        'save_path': '/downloads',
+        'content_path': '/downloads/show.mkv',
+    }
+
+    client = _make_qbittorrent_client()
+    client._get_torrents = lambda **kwargs: [torrent]
+
+    # When
+    status = client.get_status(info_hash)
+
+    # Then
+    assert str(status) == expected_status
+
+
+def test_get_status_unknown_state_does_not_raise():
+    # Given
+    info_hash = 'aabbccdd'
+    torrent = {
+        'hash': info_hash,
+        'state': 'futureState',
+        'ratio': 0,
+        'downloaded': 0,
+        'size': 0,
+        'save_path': '/downloads',
+    }
+
+    client = _make_qbittorrent_client()
+    client._get_torrents = lambda **kwargs: [torrent]
+
+    # When
+    status = client.get_status(info_hash)
+
+    # Then
+    assert status is not None
+    assert status.progress == 0
+
+
+def test_torrent_completed(requests_mock):
+    # Given
+    requests_mock.post(
+        'http://localhost/api/v2/auth/login',
+        text='Ok.',
+        status_code=200,
+    )
+    requests_mock.get(
+        'http://localhost/api/v2/app/webapiVersion',
+        text='2.0.0',
+    )
+    requests_mock.get(
+        'http://localhost/api/v2/torrents/info',
+        json=[{
+            'hash': 'aabbcc',
+            'state': 'uploading',
+            'ratio': 0,
+            'downloaded': 1000,
+            'size': 1000,
+            'save_path': '/downloads',
+            'content_path': '/downloads/show.mkv',
+        }],
+    )
 
     # When
     client = QBittorrentAPI(host='http://localhost')
     client.api = (2, 0, 0)
     client.auth = True
-    response_mock(client.name, p['method'], p['uri'])
 
     actual = client.torrent_completed('aabbcc')
 
     # Then
-    assert expected == actual
+    assert actual is True
+
+    info_requests = [
+        request for request in requests_mock.request_history
+        if request.method == 'GET'
+        and request.url.endswith('/api/v2/torrents/info')
+    ]
+    assert len(info_requests) == 1

--- a/tests/clients/test_clients.py
+++ b/tests/clients/test_clients.py
@@ -7,8 +7,54 @@ from medusa.clients.torrent import (
     deluge, deluged, downloadstation, mlnet,
     qbittorrent, rtorrent, transmission, utorrent
 )
+from medusa.clients.torrent.generic import GenericClient
 
 import pytest
+
+
+class GenericClientStub(GenericClient):
+    """Minimal GenericClient stub for torrent-state hook tests."""
+
+    def __init__(self, pause_result=True):
+        self.pause_result = pause_result
+        self.pause_calls = 0
+        self.stop_calls = 0
+
+    def _set_torrent_pause(self, result):
+        self.pause_calls += 1
+        return self.pause_result
+
+    def _set_torrent_stop(self, result):
+        self.stop_calls += 1
+        raise AssertionError('_set_torrent_stop should not be called')
+
+
+def test_set_torrent_state_calls_pause_only_success():
+    # Given
+    client = GenericClientStub(pause_result=True)
+    result = object()
+
+    # When
+    actual = client._set_torrent_state(result)
+
+    # Then
+    assert actual is True
+    assert client.pause_calls == 1
+    assert client.stop_calls == 0
+
+
+def test_set_torrent_state_calls_pause_only_failure():
+    # Given
+    client = GenericClientStub(pause_result=False)
+    result = object()
+
+    # When
+    actual = client._set_torrent_state(result)
+
+    # Then
+    assert actual is False
+    assert client.pause_calls == 1
+    assert client.stop_calls == 0
 
 
 @pytest.mark.parametrize('p', [


### PR DESCRIPTION
## Summary

Select the correct qBittorrent torrent-state endpoints from the reported
Web API version instead of relying on a failed legacy request.

## Root cause

qBittorrent 5.0 replaced:

- `pause` with `stop`
- `resume` with `start`

qBittorrent 5.0 reports Web API 2.11.2.

Medusa currently calls `pause` or `resume` first and only tries `stop` or
`start` after the legacy request fails. This produces a normal-path 404 and
can start a torrent when the user requested that it remain paused.

The qBittorrent state parser also checks `stoppdDL` instead of the actual
`stoppedDL` state.

## Changes

- Add a single torrent-state hook to the generic client.
- Preserve the state commands used by other torrent clients while no longer
  masking a failed pause operation with the qBittorrent-specific fallback.
- Use `pause`/`resume` before Web API 2.11.2.
- Use `stop`/`start` from Web API 2.11.2 onward.
- Map both paused/stopped configuration to the matching API generation.
- Map `stoppedDL` to Medusa's existing `Paused` status.
- Keep `stoppedUP` mapped to `Completed`.
- Add regression tests for qBittorrent 4.x and 5.x behavior.

## Compatibility

| Web API | Active command | Suspended command |
|---|---|---|
| `< 2.11.2` | `resume` | `pause` |
| `>= 2.11.2` | `start` | `stop` |

## Tests

- `python -m pytest tests/clients/qbittorrent.py -q`
- `python -m pytest tests/clients -q`
- local qBittorrent 5.2.1 / Web API 2.15.1 active snatch
- local stopped snatch
- `stoppedDL` and `stoppedUP` state mapping
- `git diff --check`

## Scope

This PR does not modify qBittorrent authentication, torrent addition,
categories, frontend configuration, dependencies, or the torrent files
endpoint.

Relates to pymedusa/Medusa#12195.
Related to pymedusa/Medusa#11857 and pymedusa/Medusa#12198.
