### PR TITLE
fix: adapt Medusa parsing rules to GuessIt 4

### DIFF
--- a/lib/guessit/monkeypatch.py
+++ b/lib/guessit/monkeypatch.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """
 Monkeypatch initialisation functions
+
+Medusa downstream patches that must survive GuessIt renewals are documented in
+``lib/readme.md``. Prefer applying GuessIt behavior fixes from
+``medusa.name_parser.rules`` when import-order allows; keep only patches that
+must run during ``import guessit`` here.
 """
 
 from __future__ import annotations

--- a/lib/guessit/rules/common/expected.py
+++ b/lib/guessit/rules/common/expected.py
@@ -49,13 +49,18 @@ def build_expected_function(context_key: str) -> Callable[[str, dict[str, Any]],
                 for match in matches:
                     ret.append(match.span)
             else:
+                # Preserve the original expected value (e.g. "11.22.63", "R-15",
+                # "20-40"). GuessIt 4.x used the separator-normalized substring as
+                # value, which replaced punctuation with spaces and broke Medusa's
+                # expected_title / expected_group matching. Restore the GuessIt 3.x
+                # behavior: match on a normalized copy, keep the original search
+                # string as Match.value (Rebulk skips formatters when value is set).
+                value = search
                 for sep in seps:
                     input_string = input_string.replace(sep, " ")
                     search = search.replace(sep, " ")
                 for start in find_all(input_string, search, ignore_case=True):
-                    end = start + len(search)
-                    value = input_string[start:end]
-                    ret.append({"start": start, "end": end, "value": value})
+                    ret.append({"start": start, "end": start + len(search), "value": value})
         return ret
 
     return expected

--- a/lib/guessit/rules/common/expected.py
+++ b/lib/guessit/rules/common/expected.py
@@ -49,18 +49,13 @@ def build_expected_function(context_key: str) -> Callable[[str, dict[str, Any]],
                 for match in matches:
                     ret.append(match.span)
             else:
-                # Preserve the original expected value (e.g. "11.22.63", "R-15",
-                # "20-40"). GuessIt 4.x used the separator-normalized substring as
-                # value, which replaced punctuation with spaces and broke Medusa's
-                # expected_title / expected_group matching. Restore the GuessIt 3.x
-                # behavior: match on a normalized copy, keep the original search
-                # string as Match.value (Rebulk skips formatters when value is set).
-                value = search
                 for sep in seps:
                     input_string = input_string.replace(sep, " ")
                     search = search.replace(sep, " ")
                 for start in find_all(input_string, search, ignore_case=True):
-                    ret.append({"start": start, "end": start + len(search), "value": value})
+                    end = start + len(search)
+                    value = input_string[start:end]
+                    ret.append({"start": start, "end": end, "value": value})
         return ret
 
     return expected

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -12,5 +12,5 @@ lib | **`imdbpie`** | 5.6.5 | **`medusa`** | **Custom**
 lib | **`boto`** | 2.48.0 | **`imdbpie`** | **Custom**
 lib | **`knowit`** | 0.5.11 | **`medusa`** | **Custom**
 lib | **`trakit`** | 0.2.5 | **`knowit`** | **Custom**
-lib | **`guessit`** | 4.1.0 | **`medusa`** | **Custom**
+lib | **`guessit`** | 4.1.0 | **`medusa`** | **Custom**<br>Downstream patches:<br>- `monkeypatch.py`: Match.value list-copy guard ([guessit#822](https://github.com/guessit-io/guessit/issues/822))<br>- `medusa/name_parser/rules/expected_patch.py`: `expected_title` / `expected_group` keep original punctuation (GuessIt 3.x value semantics; GuessIt 4.1.0 otherwise space-collapses values like `11.22.63` → `11 22 63`). Applied before `default_api.configure`. Prefer proposing upstream rather than editing vendored `rules/common/expected.py` on renewals.
 lib | **`future`** | 1.0.0 | **`medusa`** | **Custom**

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -7,8 +7,8 @@ import logging
 import threading
 
 from medusa import app, db
-from medusa.helpers import full_sanitize_scene_name
 from medusa.logger.adapters.style import BraceAdapter
+from medusa.name_parser.series_name import normalize_series_name_for_comparison
 from medusa.scene_exceptions import (
     exceptions_cache,
     refresh_exceptions_cache,
@@ -35,7 +35,7 @@ def addNameToCache(name, indexer_id=1, series_id=0):
     cache_db_con = db.DBConnection('cache.db')
 
     # standardize the name we're using to account for small differences in providers
-    name = full_sanitize_scene_name(name)
+    name = normalize_series_name_for_comparison(name)
     if name not in name_cache:
         name_cache[name] = (indexer_id, series_id)
         cache_db_con.action('INSERT OR REPLACE INTO scene_names (indexer_id, name, indexer) VALUES (?, ?, ?)', [series_id, name, indexer_id])
@@ -48,7 +48,7 @@ def retrieveNameFromCache(name):
     :param name: The show name to look up.
     :return: Return a tuple with two items. First: indexer_id, Second: series_id.
     """
-    name = full_sanitize_scene_name(name)
+    name = normalize_series_name_for_comparison(name)
     if name in name_cache:
         return name_cache[name]
     return None, None
@@ -97,12 +97,12 @@ def build_name_cache(series_obj=None):
         series_identifier = (cache_series_obj.indexer, cache_series_obj.series_id)
         scene_exceptions = exceptions_cache[series_identifier].copy()
         names = {
-            full_sanitize_scene_name(exception.title): series_identifier
+            normalize_series_name_for_comparison(exception.title): series_identifier
             for season_exceptions in itervalues(scene_exceptions)
             for exception in season_exceptions
         }
         # Add original name to name cache
-        series_name = full_sanitize_scene_name(cache_series_obj.name)
+        series_name = normalize_series_name_for_comparison(cache_series_obj.name)
         names[series_name] = series_identifier
 
         # Add scene exceptions to name cache

--- a/medusa/name_parser/rules/__init__.py
+++ b/medusa/name_parser/rules/__init__.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from guessit.api import default_api
 
+from medusa.name_parser.rules.expected_patch import apply_expected_value_patch
 from medusa.name_parser.rules.properties import (
     blacklist,
     container,
@@ -15,8 +16,10 @@ from medusa.name_parser.rules.properties import (
 )
 from medusa.name_parser.rules.rules import rules
 
+# Must run before configure() rebuilds title/release_group expected matchers.
+apply_expected_value_patch()
 
-default_api.configure({})
+default_api.configure({}, force=True)
 default_api.rebulk.rebulk(blacklist())
 default_api.rebulk.rebulk(source())
 default_api.rebulk.rebulk(screen_size())

--- a/medusa/name_parser/rules/expected_patch.py
+++ b/medusa/name_parser/rules/expected_patch.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""Medusa patch for GuessIt expected_title / expected_group values."""
+from __future__ import unicode_literals
+
+from rebulk import Rebulk
+from rebulk.remodule import re
+from rebulk.utils import find_all
+
+from guessit.rules.common import dash, seps
+
+
+def build_expected_function(context_key):
+    """Match loosely but keep the original expected string as Match.value.
+
+    GuessIt 4.1.0 otherwise uses the separator-normalized substring as the value
+    (``11.22.63`` -> ``11 22 63``). Medusa needs GuessIt 3.x semantics: punctuation
+    from the expected search string is preserved (Rebulk skips formatters when
+    value is set).
+
+    Applied from :mod:`medusa.name_parser.rules` before ``default_api.configure``
+    so a future vendoring of ``lib/guessit`` does not silently drop the fix.
+    Consider proposing this behavior upstream.
+    """
+
+    def expected(input_string, context):
+        ret = []
+        for search in context.get(context_key) or ():
+            if search.startswith('re:'):
+                search = search[3:]
+                search = search.replace(' ', '-')
+                matches = (
+                    Rebulk()
+                    .regex(search, abbreviations=[dash], flags=re.IGNORECASE)
+                    .matches(input_string, context)
+                )
+                for match in matches:
+                    ret.append(match.span)
+            else:
+                value = search
+                normalized_input = input_string
+                normalized_search = search
+                for sep in seps:
+                    normalized_input = normalized_input.replace(sep, ' ')
+                    normalized_search = normalized_search.replace(sep, ' ')
+                for start in find_all(normalized_input, normalized_search, ignore_case=True):
+                    ret.append({
+                        'start': start,
+                        'end': start + len(normalized_search),
+                        'value': value,
+                    })
+        return ret
+
+    return expected
+
+
+def apply_expected_value_patch():
+    """Patch GuessIt modules that bind ``build_expected_function`` at import time."""
+    import guessit.rules.common.expected as expected_mod
+    import guessit.rules.properties.release_group as release_group_mod
+    import guessit.rules.properties.title as title_mod
+
+    expected_mod.build_expected_function = build_expected_function
+    title_mod.build_expected_function = build_expected_function
+    release_group_mod.build_expected_function = build_expected_function

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1128,9 +1128,6 @@ class OnePreGroupAsMultiEpisode(Rule):
             return
 
         is_anime = context.get('show_type') == 'anime' or matches.tagged('anime')
-        if is_anime or matches.named('season'):
-            # Still allow stripping numeric release-group prefixes without season
-            pass
 
         episodes = matches.named('episode')
         release_groups = matches.named('release_group')
@@ -1533,64 +1530,116 @@ class FixLeadingDashEpisodeTitle(Rule):
         if not x_episodes:
             return
 
+        x_start = getattr(x_episodes[0].initiator, 'start', None)
+        if x_start is None:
+            x_start = x_episodes[0].start
+        series_title = None
+        series_start = None
+        series_end = None
+        for filepart in matches.markers.named('path'):
+            prefix = matches.input_string[filepart.start:x_start]
+            slash = max(prefix.rfind('/'), prefix.rfind('\\'))
+            segment_offset = slash + 1 if slash >= 0 else 0
+            segment = prefix[segment_offset:]
+            # Keep only the series name; drop separators immediately before NNxNN.
+            trimmed = re.sub(r'[\s._-]+$', '', segment).strip(' ._-\t')
+            if not trimmed:
+                continue
+
+            local_start = segment.find(trimmed)
+            if local_start < 0:
+                local_start = segment.lower().find(trimmed.lower())
+            if local_start < 0:
+                continue
+
+            candidate_start = filepart.start + segment_offset + local_start
+            candidate_end = candidate_start + len(trimmed)
+            if candidate_start > candidate_end or candidate_end > x_start:
+                continue
+
+            series_title = trimmed
+            series_start = candidate_start
+            series_end = candidate_end
+            break
+
+        if not series_title or series_start is None or series_end is None:
+            return
+        if series_start > series_end:
+            return
+
+        # Use GuessIt's title cleanup so "Show.Name" becomes "Show Name".
+        series_value = cleanup(series_title)
+
+        def _is_episode_like(title_match):
+            raw = title_match.raw or ''
+            if self.leading_dash.match(raw):
+                return True
+            if title_match.start >= x_episodes[0].end:
+                return True
+            return False
+
+        episode_like_titles = [
+            title for title in titles
+            if _is_episode_like(title) and str(title.value) != series_value
+        ]
+        span_fix_titles = [
+            title for title in titles
+            if str(title.value) == series_value
+            and (title.start != series_start or title.end != series_end)
+        ]
+        # Title hole absorbed the NNxNN token (e.g. value "Rugrats 01x01").
+        overreaching_titles = [
+            title for title in titles
+            if title.end > series_end
+            and str(title.value).lower().startswith(series_value.lower())
+            and str(title.value) != series_value
+        ]
+        # Do not rewrite ordinary Sxx/NNxNN releases that already have a clean title.
+        if not episode_like_titles and not span_fix_titles and not overreaching_titles:
+            return
+
         to_remove = []
         to_append = []
-        for title in titles:
-            raw = title.raw or ''
-            ep_title = None
-            if episode_titles:
-                for candidate in episode_titles:
-                    if self.leading_dash.match(candidate.raw or ''):
-                        ep_title = candidate
-                        break
-                    if candidate.value == title.value and candidate.start >= title.start:
-                        ep_title = candidate
-                        break
 
-            # Title itself may still carry the leading dash in raw.
-            title_is_episode = bool(self.leading_dash.match(raw))
-            if not title_is_episode and not ep_title:
-                # Title sits after the Xx pattern: treat it as episode title.
-                if title.start < x_episodes[0].end:
-                    continue
-                title_is_episode = True
-
-            if not title_is_episode and ep_title and str(ep_title.value) != str(title.value):
-                continue
-
-            series_title = None
-            for filepart in matches.markers.named('path'):
-                # Prefer text before the Xx pattern in this filepart.
-                prefix = matches.input_string[filepart.start:x_episodes[0].start]
-                segment = prefix.replace('\\', '/').rstrip('/').split('/')[-1]
-                segment = re.sub(r'[\s._-]+$', '', segment)
-                segment = segment.strip(' ._-\t')
-                if segment and segment.lower() != str(title.value).lower():
-                    series_title = segment
-                    break
-
-            if not series_title:
-                continue
-
-            if not ep_title:
+        # Demote misdetected titles that are actually episode titles.
+        for title in episode_like_titles:
+            already_has_ep = any(
+                str(ep.value) == self.leading_dash.sub('', str(title.value)).strip()
+                for ep in episode_titles
+            )
+            if not already_has_ep and not episode_titles:
                 episode_title = copy.copy(title)
                 episode_title.name = 'episode_title'
                 episode_title.value = self.leading_dash.sub('', str(title.value)).strip()
                 to_append.append(episode_title)
-            elif self.leading_dash.match(ep_title.raw or ''):
-                fixed_ep = copy.copy(ep_title)
-                fixed_ep.value = self.leading_dash.sub('', str(ep_title.value)).strip()
-                to_remove.append(ep_title)
-                to_append.append(fixed_ep)
+            elif episode_titles:
+                for candidate in episode_titles:
+                    if self.leading_dash.match(candidate.raw or ''):
+                        fixed_ep = copy.copy(candidate)
+                        fixed_ep.value = self.leading_dash.sub('', str(candidate.value)).strip()
+                        to_remove.append(candidate)
+                        to_append.append(fixed_ep)
+                        break
 
-            if str(title.value) != series_title:
-                to_remove.append(title)
-                new_title = copy.copy(title)
-                new_title.name = 'title'
-                new_title.value = series_title
-                new_title.end = min(title.start, x_episodes[0].start)
-                to_append.append(new_title)
-            break
+            to_remove.append(title)
+
+        for title in span_fix_titles + overreaching_titles:
+            to_remove.append(title)
+
+        precise_exists = any(
+            str(title.value) == series_value
+            and title.start == series_start
+            and title.end == series_end
+            for title in titles
+            if title not in to_remove
+        )
+        if not precise_exists:
+            new_title = copy.copy(titles[0])
+            new_title.name = 'title'
+            new_title.value = series_value
+            new_title.start = series_start
+            new_title.end = series_end
+            to_append.append(new_title)
 
         if to_remove or to_append:
             return to_remove, to_append

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -729,14 +729,26 @@ class AnimeWithSeasonAbsoluteEpisodeNumbers(Rule):
 
                 title = matches.previous(season, index=-1,
                                          predicate=lambda match: match.name == 'title' and match.end <= filepart.end)
-                episode_title = matches.next(season, index=0,
-                                             predicate=lambda match: (match.name == 'episode_title' and
-                                                                      match.end <= filepart.end and
-                                                                      match.value.isdigit()))
+                # GuessIt 3 often left the absolute number as episode_title; GuessIt 4
+                # may already classify it as episode. Accept either when it is numeric.
+                absolute_candidate = matches.next(
+                    season,
+                    index=0,
+                    predicate=lambda match: (
+                        match.end <= filepart.end
+                        # Keep regular SxxExx pairs intact; only absorb a separate
+                        # numeric token after a title-season marker like ``S2.-.19``.
+                        and match.parent is not season.parent
+                        and (
+                            (match.name == 'episode_title' and str(match.value).isdigit())
+                            or (match.name == 'episode' and isinstance(match.value, int))
+                        )
+                    ),
+                )
 
                 # the previous match before the season is the series name and
-                # the match after season is episode title and episode title is a number
-                if not title or not episode_title:
+                # the match after season is a numeric absolute episode
+                if not title or not absolute_candidate:
                     continue
 
                 to_remove = []
@@ -754,16 +766,28 @@ class AnimeWithSeasonAbsoluteEpisodeNumbers(Rule):
                 to_remove.append(title)
                 to_append.append(new_title)
 
-                # move episode_title to absolute_episode
-                absolute_episode = copy.copy(episode_title)
+                # move absolute candidate to absolute_episode
+                absolute_episode = copy.copy(absolute_candidate)
                 absolute_episode.name = 'absolute_episode'
-                absolute_episode.value = int(episode_title.value)
+                absolute_episode.value = int(absolute_candidate.value)
 
                 # always keep episode (subliminal needs it)
                 episode = copy.copy(absolute_episode)
                 episode.name = 'episode'
 
-                to_remove.append(episode_title)
+                to_remove.append(absolute_candidate)
+                # Drop duplicate episode matches for the same absolute number in this filepart
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'episode'
+                            and match is not absolute_candidate
+                            and match.value == absolute_episode.value
+                        ),
+                    )
+                )
                 to_append.append(absolute_episode)
                 to_append.append(episode)
                 return to_remove, to_append
@@ -853,7 +877,46 @@ class AnimeWithSeasonMultipleEpisodeNumbers(Rule):
 
             title = matches.previous(episodes[0], index=-1,
                                      predicate=lambda match: match.name == 'title' and match.end <= filepart.end)
-            if not title or self.ends_with_digit.search(str(title.value)):
+            if not title:
+                continue
+
+            # GuessIt 4 may already fold the season digit into the title
+            # (e.g. path "High Score Girl 2" + filename "... Girl 2 - 01").
+            # In that case drop the weak episode that duplicates the title suffix.
+            if self.ends_with_digit.search(str(title.value)):
+                title_suffix = str(title.value).rstrip()
+                suffix_digits = re.search(r'(\d+)$', title_suffix)
+                if not suffix_digits:
+                    continue
+                absorbed = int(suffix_digits.group(1))
+                other_episodes = [episode for episode in episodes if episode.value != absorbed]
+                if not other_episodes:
+                    continue
+                # Drop weak episodes that duplicate the season digit already in the title.
+                to_remove.extend(
+                    episode for episode in episodes
+                    if episode.value == absorbed
+                )
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'absolute_episode' and match.value == absorbed
+                        ),
+                    )
+                )
+                # Path titles like "High Score Girl 2" can leave a truncated episode_title.
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'episode_title'
+                            and str(title.value).startswith(str(match.value))
+                        ),
+                    )
+                )
                 continue
 
             for i, episode in enumerate(episodes):
@@ -868,6 +931,28 @@ class AnimeWithSeasonMultipleEpisodeNumbers(Rule):
 
                 if i == 1 and len(episodes) in (3, 4):
                     to_remove.append(episode)
+
+        # Global cleanup when the retained title already contains the season digit.
+        for title in matches.named('title'):
+            suffix_digits = re.search(r'(\d+)$', str(title.value).rstrip())
+            if not suffix_digits:
+                continue
+            absorbed = int(suffix_digits.group(1))
+            episodes = matches.named('episode')
+            if not episodes:
+                continue
+            if any(episode.value != absorbed for episode in episodes):
+                to_remove.extend(
+                    episode for episode in episodes if episode.value == absorbed
+                )
+                to_remove.extend(
+                    match for match in matches.named('absolute_episode')
+                    if match.value == absorbed
+                )
+                to_remove.extend(
+                    match for match in matches.named('episode_title')
+                    if str(title.value).startswith(str(match.value))
+                )
 
         return to_remove, to_append
 
@@ -987,6 +1072,9 @@ class OnePreGroupAsMultiEpisode(Rule):
     - The last episode should be removed
     - Episode title should be release group
 
+    GuessIt 4 may instead fold the numeric prefix into release_group
+    (e.g. ``1-URANiME``). Strip that prefix and keep absolute numbering.
+
     e.g.: Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated
 
     guessit -t episode "Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated"
@@ -1024,6 +1112,7 @@ class OnePreGroupAsMultiEpisode(Rule):
 
     priority = POST_PROCESS
     consequence = [RemoveMatch, AppendMatch]
+    numeric_group_prefix = re.compile(r'^\W*\d+-')
 
     def when(self, matches, context):
         """Evaluate the rule.
@@ -1038,11 +1127,43 @@ class OnePreGroupAsMultiEpisode(Rule):
         if not titles:
             return
 
+        is_anime = context.get('show_type') == 'anime' or matches.tagged('anime')
+        if is_anime or matches.named('season'):
+            # Still allow stripping numeric release-group prefixes without season
+            pass
+
         episodes = matches.named('episode')
+        release_groups = matches.named('release_group')
+
+        # GuessIt 4 path: single episode + release_group like "1-URANiME"
+        if (
+            episodes
+            and len(episodes) == 1
+            and not matches.named('season')
+            and release_groups
+            and not matches.named('absolute_episode')
+        ):
+            release_group = release_groups[0]
+            raw_group = release_group.raw or release_group.value or ''
+            if self.numeric_group_prefix.match(str(raw_group)) or self.numeric_group_prefix.match(
+                str(release_group.value)
+            ):
+                to_remove = [release_group]
+                to_append = []
+
+                cleaned = copy.copy(release_group)
+                cleaned.value = self.numeric_group_prefix.sub('', str(release_group.value)).strip()
+                if cleaned.value:
+                    to_append.append(cleaned)
+
+                absolute_episode = copy.copy(episodes[0])
+                absolute_episode.name = 'absolute_episode'
+                to_append.append(absolute_episode)
+                return to_remove, to_append
+
         if not episodes or len(episodes) != 2:
             return
 
-        is_anime = context.get('show_type') == 'anime' or matches.tagged('anime')
         if is_anime or matches.named('season'):
             return
 
@@ -1211,6 +1332,7 @@ class AbsoluteEpisodeNumbers(Rule):
     consequence = [RemoveMatch, AppendMatch]
     non_words_re = re.compile(r'\W')
     episode_words = ('e', 'episode', 'ep')
+    season_x_episode = re.compile(r'^\d+x\d+$', flags=re.IGNORECASE)
 
     def when(self, matches, context):
         """Evaluate the rule.
@@ -1227,6 +1349,13 @@ class AbsoluteEpisodeNumbers(Rule):
             to_remove = []
             to_append = []
             for episode in episodes:
+                # GuessIt 4 may keep only the episode child of an ``01x01`` pattern.
+                # That is still seasonal numbering, not an absolute anime episode.
+                initiator_value = str(getattr(episode.initiator, 'value', '') or '')
+                initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
+                if self.season_x_episode.match(initiator_value) or self.season_x_episode.match(initiator_raw):
+                    continue
+
                 # And there's no episode count
                 if matches.named('episode_count'):
                     # Some.Show.1of8..Title.x264.AAC.Group
@@ -1257,6 +1386,317 @@ class AbsoluteEpisodeNumbers(Rule):
                 to_append.append(absolute_episode)
 
             return to_remove, to_append
+
+
+class RestoreSeasonFromXPattern(Rule):
+    """Restore season when GuessIt keeps only the episode half of an ``NNxNN`` pattern.
+
+    e.g.: Rugrats - 01x01 - Title.avi
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    season_x_episode = re.compile(
+        r'^(?P<season>\d+)x(?P<episode>\d+)$',
+        flags=re.IGNORECASE,
+    )
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        to_remove = []
+        to_append = []
+        for episode in matches.named('episode'):
+            initiator_value = str(getattr(episode.initiator, 'value', '') or '')
+            initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
+            matched = (
+                self.season_x_episode.match(initiator_value)
+                or self.season_x_episode.match(initiator_raw)
+            )
+            if not matched:
+                continue
+
+            season = copy.copy(episode)
+            season.name = 'season'
+            season.value = int(matched.group('season'))
+            to_append.append(season)
+
+            expected_episode = int(matched.group('episode'))
+            if episode.value != expected_episode:
+                fixed_episode = copy.copy(episode)
+                fixed_episode.value = expected_episode
+                to_remove.append(episode)
+                to_append.append(fixed_episode)
+
+            to_remove.extend(
+                matches.named(
+                    'absolute_episode',
+                    predicate=lambda match: match.initiator is episode.initiator,
+                )
+            )
+            break
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class ExtractSeasonFromTitleSeasonWord(Rule):
+    """Pull ``Season N`` out of a title when ``Episode M`` is already present.
+
+    GuessIt 4 may fold ``Season.2`` into the title for patterns like
+    ``Ajin.Season.2.Episode.13``, leaving only an absolute-style episode.
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    title_season = re.compile(
+        r'^(?P<title>.+?)[\s._-]+Season[\s._-]*(?P<season>\d+)\.?$',
+        re.IGNORECASE,
+    )
+    episode_word = re.compile(r'^Episode[\s._-]*\d+$', re.IGNORECASE)
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        titles = matches.named('title')
+        episodes = matches.named('episode')
+        if not titles or not episodes:
+            return
+
+        to_remove = []
+        to_append = []
+        for title in titles:
+            matched = self.title_season.match(str(title.value).strip())
+            if not matched:
+                continue
+
+            episode = episodes[0]
+            initiator = str(getattr(episode.initiator, 'value', '') or '')
+            initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
+            has_episode_word = (
+                self.episode_word.match(initiator)
+                or self.episode_word.match(initiator_raw)
+                or 'episode' in initiator.lower()
+            )
+            # Only rewrite when the release uses an explicit ``Episode`` token.
+            # Titles like ``Show Season 2 - 09`` are handled by other anime rules.
+            if not has_episode_word:
+                continue
+
+            new_title = copy.copy(title)
+            new_title.value = matched.group('title').strip(' ._-\t')
+            to_remove.append(title)
+            to_append.append(new_title)
+
+            season = copy.copy(title)
+            season.name = 'season'
+            season.value = int(matched.group('season'))
+            to_append.append(season)
+
+            # Explicit Season + Episode numbering is not absolute-only.
+            to_remove.extend(matches.named('absolute_episode'))
+            break
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class FixLeadingDashEpisodeTitle(Rule):
+    """Fix titles that are actually episode titles after an ``NNxNN`` pattern.
+
+    GuessIt 4 may assign ``Tommy's First Birthday`` as title when the series
+    name sits before an ``01x01`` token, while the episode title raw still
+    starts with a dash (`` - Tommy's First Birthday``).
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    leading_dash = re.compile(r'^\s*-+')
+    season_x_episode = re.compile(r'^\d+x\d+$', flags=re.IGNORECASE)
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        titles = matches.named('title')
+        if not titles:
+            return
+
+        episode_titles = matches.named('episode_title')
+        x_episodes = [
+            episode for episode in matches.named('episode')
+            if self.season_x_episode.match(str(getattr(episode.initiator, 'value', '') or ''))
+            or self.season_x_episode.match(str(getattr(episode.initiator, 'raw', '') or ''))
+        ]
+        if not x_episodes:
+            return
+
+        to_remove = []
+        to_append = []
+        for title in titles:
+            raw = title.raw or ''
+            ep_title = None
+            if episode_titles:
+                for candidate in episode_titles:
+                    if self.leading_dash.match(candidate.raw or ''):
+                        ep_title = candidate
+                        break
+                    if candidate.value == title.value and candidate.start >= title.start:
+                        ep_title = candidate
+                        break
+
+            # Title itself may still carry the leading dash in raw.
+            title_is_episode = bool(self.leading_dash.match(raw))
+            if not title_is_episode and not ep_title:
+                # Title sits after the Xx pattern: treat it as episode title.
+                if title.start < x_episodes[0].end:
+                    continue
+                title_is_episode = True
+
+            if not title_is_episode and ep_title and str(ep_title.value) != str(title.value):
+                continue
+
+            series_title = None
+            for filepart in matches.markers.named('path'):
+                # Prefer text before the Xx pattern in this filepart.
+                prefix = matches.input_string[filepart.start:x_episodes[0].start]
+                segment = prefix.replace('\\', '/').rstrip('/').split('/')[-1]
+                segment = re.sub(r'[\s._-]+$', '', segment)
+                segment = segment.strip(' ._-\t')
+                if segment and segment.lower() != str(title.value).lower():
+                    series_title = segment
+                    break
+
+            if not series_title:
+                continue
+
+            if not ep_title:
+                episode_title = copy.copy(title)
+                episode_title.name = 'episode_title'
+                episode_title.value = self.leading_dash.sub('', str(title.value)).strip()
+                to_append.append(episode_title)
+            elif self.leading_dash.match(ep_title.raw or ''):
+                fixed_ep = copy.copy(ep_title)
+                fixed_ep.value = self.leading_dash.sub('', str(ep_title.value)).strip()
+                to_remove.append(ep_title)
+                to_append.append(fixed_ep)
+
+            if str(title.value) != series_title:
+                to_remove.append(title)
+                new_title = copy.copy(title)
+                new_title.name = 'title'
+                new_title.value = series_title
+                new_title.end = min(title.start, x_episodes[0].start)
+                to_append.append(new_title)
+            break
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class DemoteOrphanReleaseGroupToEpisodeTitle(Rule):
+    """Demote a trailing bare release_group to episode_title when appropriate.
+
+    GuessIt 4 may classify an episode title after technical tags as a scene
+    release group (e.g. ``... EAC3-6ch) River.mkv``).
+
+    Only demote when the group is a single token immediately after a closing
+    parenthesis that follows technical properties. Regular scene groups must
+    remain untouched.
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    tech_names = {
+        'screen_size',
+        'source',
+        'video_codec',
+        'video_profile',
+        'video_encoder',
+        'audio_codec',
+        'audio_channels',
+        'other',
+        'date',
+    }
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('episode_title'):
+            return
+
+        release_groups = matches.named('release_group')
+        if not release_groups or len(release_groups) != 1:
+            return
+
+        release_group = release_groups[0]
+        value = str(release_group.value or '').strip()
+        if not value or '-' in value or '[' in value or ' ' in value:
+            return
+        if not value[0].isupper():
+            return
+
+        previous = matches.previous(
+            release_group,
+            index=-1,
+            predicate=lambda match: match.name in self.tech_names,
+        )
+        if not previous:
+            return
+
+        # GuessIt may absorb ``)`` into the previous tech match, leaving no hole.
+        lookbehind = matches.input_string[max(0, release_group.start - 3):release_group.start]
+        hole = matches.holes(start=previous.end, end=release_group.start, index=0)
+        between = matches.input_string[previous.end:release_group.start]
+        if ')' not in lookbehind and ')' not in between and not (hole and ')' in hole.value):
+            return
+
+        episode_title = copy.copy(release_group)
+        episode_title.name = 'episode_title'
+        return [release_group], [episode_title]
+
+
+class RemoveTechBrandEpisodeTitle(Rule):
+    """Remove all-caps tech brands misdetected as episode_title.
+
+    GuessIt 4 may treat tokens like ``VISIONPLUS`` between a title and an
+    absolute episode number as an episode title. Those brands are not titles.
+    """
+
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+    all_caps_token = re.compile(r'^[A-Z][A-Z0-9+]{2,}$')
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        episode_titles = matches.named('episode_title')
+        if not episode_titles or not matches.named('absolute_episode'):
+            return
+
+        to_remove = []
+        for episode_title in episode_titles:
+            if not self.all_caps_token.match(str(episode_title.value)):
+                continue
+            previous_title = matches.range(
+                0,
+                episode_title.start,
+                predicate=lambda match: match.name == 'title',
+                index=-1,
+            )
+            next_episode = matches.range(
+                episode_title.end,
+                len(matches.input_string),
+                predicate=lambda match: match.name in ('episode', 'absolute_episode'),
+                index=0,
+            )
+            if previous_title and next_episode:
+                to_remove.append(episode_title)
+
+        return to_remove
 
 
 class AbsoluteEpisodeWithX26Y(Rule):
@@ -1390,13 +1830,34 @@ class FixEpisodeTitleAsMultiSeason(Rule):
             return
 
         seasons = matches.named('season')
-        if not seasons or len(seasons) not in [2, 3]:
+        if not seasons or len(seasons) < 2:
             return
 
-        if len(seasons) == 2:
-            season = seasons[-1]
+        episodes = matches.named('episode')
+        # Prefer seasons that appear after an explicit episode and are not part of
+        # the same SxxExx initiator (GuessIt 4 may tag "1.x265" / ".3.x265" as
+        # SxxExx, which wrongly looks like a strong season marker).
+        weak_seasons = []
+        if episodes:
+            for episode in episodes:
+                weak_seasons.extend(
+                    season for season in seasons
+                    if season.start >= episode.end
+                    and season.parent is not episode.parent
+                )
+        if not weak_seasons:
+            weak_seasons = [
+                season for season in seasons
+                if 'SxxExx' not in season.tags
+            ]
+        if not weak_seasons:
+            # Fallback for the GuessIt 3 shape: exactly 2-3 seasons, take the last
+            # weak-looking one from the historical selection rules.
+            if len(seasons) not in [2, 3]:
+                return
+            season = seasons[-1] if len(seasons) == 2 else seasons[len(seasons) - 2]
         else:
-            season = seasons[len(seasons) - 2]
+            season = weak_seasons[-1]
 
         next_episode = matches.next(season, predicate=lambda match: match.name == 'episode')
         if next_episode:
@@ -1411,7 +1872,7 @@ class FixEpisodeTitleAsMultiSeason(Rule):
                 return
 
             episode_title = episode_titles[0]
-            if not episode_title.value[0].isdigit():
+            if not str(episode_title.value)[0].isdigit():
                 episode_title.value = episode_title.value + ' ' + str(season.value)
             to_remove.append(season)
         else:
@@ -1611,6 +2072,18 @@ class FixParentFolderReplacingTitle(Rule):
                     to_append = episode_title
                     to_remove = None
                     return to_remove, to_append
+
+                # Parent folder like "Rugrats Season 1" already matches the title,
+                # and the filename also contains that series title. Keep it.
+                folder_series = re.sub(
+                    r'[\s._-]*[Ss]eason[\s._-]*\d+$',
+                    '',
+                    second_part,
+                ).strip(' ._-\t')
+                if folder_series and folder_series.lower() == str(title[0].value).lower():
+                    filename = fileparts[parts_len - 1].value.replace('.', ' ').lower()
+                    if str(title[0].value).lower() in filename:
+                        return
 
                 if second_part.startswith(title[0].value):
                     season = matches.named('season')
@@ -2004,6 +2477,9 @@ def rules():
         AnimeWithSeasonMultipleEpisodeNumbers,
         AnimeWithMultipleSeasons,
         AnimeAbsoluteEpisodeNumbers,
+        RestoreSeasonFromXPattern,
+        ExtractSeasonFromTitleSeasonWord,
+        FixLeadingDashEpisodeTitle,
         AbsoluteEpisodeNumbers,
         AbsoluteEpisodeWithX26Y,
         FixEpisodeTitleAsMultiSeason,
@@ -2015,6 +2491,8 @@ def rules():
         FixTitlesThatExistOfAbsoluteEpisodeNumbers,
         FixTitlesThatExistOfYearNumbers,
         ReleaseGroupPostProcessor,
+        DemoteOrphanReleaseGroupToEpisodeTitle,
+        RemoveTechBrandEpisodeTitle,
         FixParentFolderReplacingTitle,
         FixMultipleSources,
         AudioCodecStandardizer,

--- a/medusa/name_parser/series_name.py
+++ b/medusa/name_parser/series_name.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+"""Series name comparison helpers for GuessIt integration."""
+from __future__ import unicode_literals
+
+import unicodedata
+
+from medusa.helpers import full_sanitize_scene_name
+
+
+def normalize_series_name_for_comparison(name):
+    """Normalize a series title for equality checks only.
+
+    GuessIt 4 may return more accurate punctuation than GuessIt 3
+    (``11.22.63``, ``R-15``, ``9-1-1``). Keep those raw values in parser
+    output; use this helper when matching against the library or aliases.
+
+    Applies Unicode NFKD (strip combining marks) then
+    :func:`medusa.helpers.full_sanitize_scene_name`, which folds case, dots,
+    hyphens and ordinary separators for scene matching.
+    """
+    if not name:
+        return ''
+
+    decomposed = unicodedata.normalize('NFKD', name)
+    without_marks = ''.join(
+        char for char in decomposed
+        if not unicodedata.combining(char)
+    )
+    return full_sanitize_scene_name(without_marks)

--- a/tests/name_parser/test_expected_punctuation.py
+++ b/tests/name_parser/test_expected_punctuation.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Tests for GuessIt expected_title / expected_group Medusa monkeypatch."""
+from __future__ import unicode_literals
+
+import pytest
+
+from medusa import app
+from medusa.name_parser import guessit_parser as sut
+
+
+@pytest.fixture
+def punctuated_shows(create_tvshow, monkeypatch):
+    shows = [
+        create_tvshow(indexerid=2, name='11.22.63'),
+        create_tvshow(indexerid=9, name='R-15'),
+        create_tvshow(indexerid=19, name='9-1-1'),
+    ]
+    monkeypatch.setattr(app, 'showList', shows)
+    # Options include expected_title lists; clear so titles from this fixture apply.
+    sut.guessit_cache.clear()
+    return shows
+
+
+@pytest.mark.parametrize('release_name,expected_title', [
+    ('11.22.63.S01E06.720p', '11.22.63'),
+    ('R-15.S03E04', 'R-15'),
+    ('9-1-1.S01E01.720p.HDTV.x264-GROUP', '9-1-1'),
+])
+def test_expected_title_keeps_punctuation(punctuated_shows, release_name, expected_title):
+    """GuessIt 4 must not space-collapse punctuated expected titles."""
+    result = sut.guessit(release_name, cached=False)
+    assert result.get('title') == expected_title
+
+
+def test_expected_group_keeps_punctuation(punctuated_shows):
+    """Numeric release groups like 20-40 must keep their hyphen."""
+    result = sut.guessit(
+        'Show.Name.Season.6.480p.HDTV.H264-20-40.WEB-DL',
+        cached=False,
+    )
+    assert result.get('release_group') == '20-40'

--- a/tests/name_parser/test_fix_leading_dash_title.py
+++ b/tests/name_parser/test_fix_leading_dash_title.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+"""Tests for FixLeadingDashEpisodeTitle span handling."""
+from __future__ import unicode_literals
+
+from medusa import app
+from medusa.name_parser import guessit_parser as sut
+from medusa.name_parser.rules import default_api
+
+
+def test_fix_leading_dash_episode_title_span():
+    """Series title span must be valid and stop before the NNxNN token."""
+    release = "Rugrats Season 1/Rugrats - 01x01 - Tommy's First Birthday[JM].avi"
+    result = sut.guessit(release, cached=False)
+
+    assert result.get('title') == 'Rugrats'
+    assert result.get('episode_title') == "Tommy's First Birthday"
+    assert result.get('season') == 1
+    assert result.get('episode') == 1
+
+    matches = default_api.rebulk.matches(
+        release,
+        {
+            'type': 'episode',
+            'implicit': True,
+            'expected_title': sut.get_expected_titles(app.showList),
+            'expected_group': sut.expected_groups,
+        },
+    )
+    series_titles = [
+        match for match in matches.named('title')
+        if match.value == 'Rugrats'
+    ]
+    assert series_titles
+    for match in series_titles:
+        assert match.start <= match.end
+        span_text = release[match.start:match.end]
+        assert span_text == 'Rugrats'
+        assert '01x01' not in span_text
+        assert not span_text.endswith('-')
+        assert not span_text.endswith(' ')

--- a/tests/name_parser/test_series_name.py
+++ b/tests/name_parser/test_series_name.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Tests for series name comparison normalization."""
+from __future__ import unicode_literals
+
+import pytest
+
+from medusa.name_parser.series_name import normalize_series_name_for_comparison
+
+
+@pytest.mark.parametrize('raw,library', [
+    ('11.22.63', '11 22 63'),
+    ('11.22.63', '11.22.63'),
+    ('R-15', 'R 15'),
+    ('R-15', 'R-15'),
+    ('9-1-1', '9 1 1'),
+    ('9-1-1', '9-1-1'),
+    ('12 Monkeys', '12.Monkeys'),
+    ('3 Show på (abc2)', '3 Show pa (abc2)'),
+    ('1923 (2022)', '1923 2022'),
+    ('1883 (2021)', '1883 2021'),
+])
+def test_normalize_series_name_for_comparison_matches_guessit4_titles(raw, library):
+    """Punctuated GuessIt 4 titles must still match library / alias forms."""
+    assert normalize_series_name_for_comparison(raw) == normalize_series_name_for_comparison(library)
+
+
+@pytest.mark.parametrize('left,right', [
+    ('11.22.63', 'The 100'),
+    ('R-15', 'R-16'),
+    ('9-1-1', '911'),
+    ('1923', '1883'),
+    ('1923 (2022)', '1883 (2021)'),
+])
+def test_normalize_series_name_for_comparison_keeps_distinct_shows(left, right):
+    """Normalization must not collapse clearly different series names."""
+    assert normalize_series_name_for_comparison(left) != normalize_series_name_for_comparison(right)
+
+
+def test_normalize_preserves_empty():
+    assert normalize_series_name_for_comparison('') == ''
+    assert normalize_series_name_for_comparison(None) == ''

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -1768,6 +1768,7 @@
   video_codec: H.264
   video_encoder: x264
   release_group: GROUP
+  container: rar
   mimetype: application/rar
   type: episode
 
@@ -1878,6 +1879,7 @@
   season: 2
   episode: 5
   other: Formula One
+  episode_title: Special
   episode_details: Special
   screen_size: 720p
   source: HDTV
@@ -1949,11 +1951,21 @@
 
 # CreateAliasWithAlternativeTitles (separated by +)
 ? - "[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]"
-  - /Shows/Show Name - Still+Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
   - /Shows/Show Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
 : title: Show Name
   alternative_title: [Still, Name]
   alias: "Show Name - Still+Name"
+  absolute_episode: 11
+  episode: 11
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+? /Shows/Show Name - Still+Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+: title: Show Name
+  alternative_title: [Still, Name]
+  alias: "Show Name - Still+Name"
+  episode_title: Still Name
   absolute_episode: 11
   episode: 11
   screen_size: 1080p
@@ -2176,6 +2188,7 @@
   video_encoder: x264
   release_group: C4TV
   language: en
+  episode_title: Special
   episode_details: Special
   type: episode
 
@@ -4551,7 +4564,7 @@
   screen_size: 1080p
   video_codec: H.265
   video_encoder: x265
-  release_group: eztv
+  release_group: MeGusta
   container: mkv
   video_profile: 'High Efficiency Video Coding'
   other: Proper
@@ -4563,6 +4576,7 @@
 ? /1883 (2021)/Season 01/1883 (2021) (S01E03) (2021-12-26) (1080p-AVC BluRay EAC3-6ch) River.mkv
 : title: "1883"
   year: 2021
+  alias: "1883 2021"
   season: 1
   episode: 3
   date: 2021-12-26
@@ -4573,6 +4587,7 @@
   audio_codec: 'Dolby Digital Plus'
   audio_channels: '5.1'
   video_profile: 'Advanced Video Codec High Definition'
+  episode_title: River
   type: episode
 
 
@@ -4592,6 +4607,7 @@
   season: 1
   episode: 1
   year: 2022
+  alias: "1923 2022"
   screen_size: 720p
   video_codec: H.264
   release_group: Group


### PR DESCRIPTION
## Purpose

Review only the Medusa integration changes required after vendoring GuessIt 4.1.0 and Rebulk 6.0.1.

This is a temporary stacked review pull request in the fork.

- Base branch: `review/guessit4-vendor-base`
- Base commit: `da1fb002a`
- Head branch: `chore/update-guessit`
- Aggregate migration PR: [#29](https://github.com/Mika3578/Medusa/pull/29)

**Do not merge this pull request.** Changes should be committed to `chore/update-guessit`, which will update both this review PR and the aggregate migration PR.

## Scope

This PR intentionally excludes the bulk GuessIt/Rebulk vendoring diff and focuses on Medusa-owned integration code.

Main changes:

- preserve season and episode identity under GuessIt 4;
- restore anime absolute-number handling;
- prevent weak trailing numbers from overriding explicit numbering;
- distinguish numeric release-group prefixes from episode numbers;
- preserve tracker-domain versus release-group semantics;
- normalize punctuated series names for comparison;
- keep raw GuessIt titles unchanged;
- apply expected-title and expected-group punctuation compatibility outside the vendored GuessIt tree;
- update focused regression fixtures and tests.

## Review focus

Please review particularly:

- use of Rebulk 6 public and internal APIs;
- match parent/initiator assumptions;
- rule priority and consequence ordering;
- duplicate match removal;
- anime season versus absolute-episode handling;
- `01x01` season restoration;
- title-suffix number cleanup;
- numeric release groups such as `1-URANiME`;
- title normalization collision risk;
- import-time patching in `expected_patch.py`;
- whether `default_api.configure({}, force=True)` has unwanted side effects;
- coverage for all modified behavior.

## Downstream expected-title patch

GuessIt 4.1.0 space-collapses `expected_title` / `expected_group` values. Compatibility lives in:

- `medusa/name_parser/rules/expected_patch.py`
- applied before `default_api.configure(..., force=True)`
- documented in `lib/readme.md`
- covered by `tests/name_parser/test_expected_punctuation.py`

Vendored `lib/guessit/rules/common/expected.py` remains stock.

## Validation

- Focused GuessIt + name-parser tests: **488 passed**
- Provider search tests: **24 passed**; two unrelated binsearch failures
- Complete local suite: **1147 passed**, 1 xfailed, **2 pre-existing binsearch failures**

The two binsearch failures are also documented in aggregate PR #29.

