### PR TITLE
feat: parse month/year scene releases for monthly air-by-date shows

### DIFF
--- a/medusa/helper/month_names.py
+++ b/medusa/helper/month_names.py
@@ -1,0 +1,536 @@
+# coding=utf-8
+"""Month name helpers for monthly show parsing and search templates.
+
+Languages follow Medusa indexer valid_languages:
+  da, fi, nl, de, it, es, fr, pl, hu, el, tr, ru, he, ja, pt, zh, cs, sl, hr,
+  ko, en, sv, no
+
+Used by:
+- guessit month/year release parsing
+- episode naming / search template tokens %MM and %Mm
+
+Scene-oriented Latin spellings prefer unaccented forms when scene packs
+typically drop diacritics. Index 0 is unused; months are 1..12.
+"""
+from __future__ import unicode_literals
+
+import unicodedata
+from datetime import date
+
+# Alias non-ISO codes used elsewhere in Medusa (e.g. guessit allowed_languages).
+_LANG_ALIASES = {
+    'jp': 'ja',
+    'nb': 'no',
+    'nn': 'no',
+    'iw': 'he',
+    'cn': 'zh',
+}
+
+MONTH_NAMES_FULL = {
+    'en': (
+        None,
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December',
+    ),
+    'fr': (
+        None,
+        'Janvier', 'Fevrier', 'Mars', 'Avril', 'Mai', 'Juin',
+        'Juillet', 'Aout', 'Septembre', 'Octobre', 'Novembre', 'Decembre',
+    ),
+    'es': (
+        None,
+        'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+        'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+    ),
+    'de': (
+        None,
+        'Januar', 'Februar', 'Marz', 'April', 'Mai', 'Juni',
+        'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+    ),
+    'it': (
+        None,
+        'Gennaio', 'Febbraio', 'Marzo', 'Aprile', 'Maggio', 'Giugno',
+        'Luglio', 'Agosto', 'Settembre', 'Ottobre', 'Novembre', 'Dicembre',
+    ),
+    'pt': (
+        None,
+        'Janeiro', 'Fevereiro', 'Marco', 'Abril', 'Maio', 'Junho',
+        'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+    ),
+    'nl': (
+        None,
+        'Januari', 'Februari', 'Maart', 'April', 'Mei', 'Juni',
+        'Juli', 'Augustus', 'September', 'Oktober', 'November', 'December',
+    ),
+    'da': (
+        None,
+        'Januar', 'Februar', 'Marts', 'April', 'Maj', 'Juni',
+        'Juli', 'August', 'September', 'Oktober', 'November', 'December',
+    ),
+    'sv': (
+        None,
+        'Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni',
+        'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December',
+    ),
+    'no': (
+        None,
+        'Januar', 'Februar', 'Mars', 'April', 'Mai', 'Juni',
+        'Juli', 'August', 'September', 'Oktober', 'November', 'Desember',
+    ),
+    'fi': (
+        None,
+        'Tammikuu', 'Helmikuu', 'Maaliskuu', 'Huhtikuu', 'Toukokuu', 'Kesakuu',
+        'Heinakuu', 'Elokuu', 'Syyskuu', 'Lokakuu', 'Marraskuu', 'Joulukuu',
+    ),
+    'pl': (
+        None,
+        'Styczen', 'Luty', 'Marzec', 'Kwiecien', 'Maj', 'Czerwiec',
+        'Lipiec', 'Sierpien', 'Wrzesien', 'Pazdziernik', 'Listopad', 'Grudzien',
+    ),
+    'cs': (
+        None,
+        'Leden', 'Unor', 'Brezen', 'Duben', 'Kveten', 'Cerven',
+        'Cervenec', 'Srpen', 'Zari', 'Rijen', 'Listopad', 'Prosinec',
+    ),
+    'sl': (
+        None,
+        'Januar', 'Februar', 'Marec', 'April', 'Maj', 'Junij',
+        'Julij', 'Avgust', 'September', 'Oktober', 'November', 'December',
+    ),
+    'hr': (
+        None,
+        'Sijecanj', 'Veljaca', 'Ozujak', 'Travanj', 'Svibanj', 'Lipanj',
+        'Srpanj', 'Kolovoz', 'Rujan', 'Listopad', 'Studeni', 'Prosinac',
+    ),
+    'hu': (
+        None,
+        'Januar', 'Februar', 'Marcius', 'Aprilis', 'Majus', 'Junius',
+        'Julius', 'Augusztus', 'Szeptember', 'Oktober', 'November', 'December',
+    ),
+    'ro': (
+        None,
+        'Ianuarie', 'Februarie', 'Martie', 'Aprilie', 'Mai', 'Iunie',
+        'Iulie', 'August', 'Septembrie', 'Octombrie', 'Noiembrie', 'Decembrie',
+    ),
+    'tr': (
+        None,
+        'Ocak', 'Subat', 'Mart', 'Nisan', 'Mayis', 'Haziran',
+        'Temmuz', 'Agustos', 'Eylul', 'Ekim', 'Kasim', 'Aralik',
+    ),
+    'el': (
+        None,
+        'Ianouarios', 'Fevrouarios', 'Martios', 'Aprilios', 'Maios', 'Iounios',
+        'Ioulios', 'Avgoustos', 'Septemvrios', 'Oktovrios', 'Noemvrios', 'Dekemvrios',
+    ),
+    'ru': (
+        None,
+        'Yanvar', 'Fevral', 'Mart', 'Aprel', 'May', 'Iyun',
+        'Iyul', 'Avgust', 'Sentyabr', 'Oktyabr', 'Noyabr', 'Dekabr',
+    ),
+    'he': (
+        None,
+        'Yanuar', 'Fbruar', 'Martz', 'April', 'Mai', 'Yuni',
+        'Yuli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+    ),
+    'ja': (
+        None,
+        '1月', '2月', '3月', '4月', '5月', '6月',
+        '7月', '8月', '9月', '10月', '11月', '12月',
+    ),
+    'zh': (
+        None,
+        '一月', '二月', '三月', '四月', '五月', '六月',
+        '七月', '八月', '九月', '十月', '十一月', '十二月',
+    ),
+    'ko': (
+        None,
+        '1월', '2월', '3월', '4월', '5월', '6월',
+        '7월', '8월', '9월', '10월', '11월', '12월',
+    ),
+}
+
+MONTH_NAMES_ABBR = {
+    'en': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ),
+    'fr': (
+        None,
+        'Janv', 'Fevr', 'Mars', 'Avr', 'Mai', 'Juin',
+        'Juil', 'Aout', 'Sept', 'Oct', 'Nov', 'Dec',
+    ),
+    'es': (
+        None,
+        'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+        'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+    ),
+    'de': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez',
+    ),
+    'it': (
+        None,
+        'Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu',
+        'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic',
+    ),
+    'pt': (
+        None,
+        'Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun',
+        'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez',
+    ),
+    'nl': (
+        None,
+        'Jan', 'Feb', 'Mrt', 'Apr', 'Mei', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec',
+    ),
+    'da': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec',
+    ),
+    'sv': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec',
+    ),
+    'no': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Des',
+    ),
+    'fi': (
+        None,
+        'Tammi', 'Helmi', 'Maalis', 'Huhti', 'Touko', 'Kesa',
+        'Heina', 'Elo', 'Syys', 'Loka', 'Marras', 'Joulu',
+    ),
+    'pl': (
+        None,
+        'Sty', 'Lut', 'Mar', 'Kwi', 'Maj', 'Cze',
+        'Lip', 'Sie', 'Wrz', 'Paz', 'Lis', 'Gru',
+    ),
+    'cs': (
+        None,
+        'Led', 'Uno', 'Bre', 'Dub', 'Kve', 'Cer',
+        'Cvc', 'Srp', 'Zar', 'Rij', 'Lis', 'Pro',
+    ),
+    'sl': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+        'Jul', 'Avg', 'Sep', 'Okt', 'Nov', 'Dec',
+    ),
+    'hr': (
+        None,
+        'Sij', 'Velj', 'Ozu', 'Tra', 'Svi', 'Lip',
+        'Srp', 'Kol', 'Ruj', 'Lis', 'Stu', 'Pro',
+    ),
+    'hu': (
+        None,
+        'Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun',
+        'Jul', 'Aug', 'Sze', 'Okt', 'Nov', 'Dec',
+    ),
+    'ro': (
+        None,
+        'Ian', 'Feb', 'Mar', 'Apr', 'Mai', 'Iun',
+        'Iul', 'Aug', 'Sep', 'Oct', 'Noi', 'Dec',
+    ),
+    'tr': (
+        None,
+        'Oca', 'Sub', 'Mar', 'Nis', 'May', 'Haz',
+        'Tem', 'Agu', 'Eyl', 'Eki', 'Kas', 'Ara',
+    ),
+    'el': (
+        None,
+        'Ian', 'Fev', 'Mar', 'Apr', 'Mai', 'Ioun',
+        'Ioul', 'Avg', 'Sep', 'Okt', 'Noe', 'Dek',
+    ),
+    'ru': (
+        None,
+        'Yan', 'Fev', 'Mar', 'Apr', 'May', 'Iyn',
+        'Iyl', 'Avg', 'Sen', 'Okt', 'Noy', 'Dek',
+    ),
+    'he': (
+        None,
+        'Yan', 'Fbr', 'Mar', 'Apr', 'Mai', 'Yun',
+        'Yul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez',
+    ),
+    'ja': MONTH_NAMES_FULL['ja'],
+    'zh': (
+        None,
+        '1月', '2月', '3月', '4月', '5月', '6月',
+        '7月', '8月', '9月', '10月', '11月', '12月',
+    ),
+    'ko': MONTH_NAMES_FULL['ko'],
+}
+
+# Reverse map for parsing release names (accented + unaccented + common forms).
+MONTH_NAME_TO_NUMBER = {
+    # English
+    'january': 1, 'jan': 1,
+    'february': 2, 'feb': 2,
+    'march': 3, 'mar': 3,
+    'april': 4, 'apr': 4,
+    'may': 5,
+    'june': 6, 'jun': 6,
+    'july': 7, 'jul': 7,
+    'august': 8, 'aug': 8,
+    'september': 9, 'sep': 9, 'sept': 9,
+    'october': 10, 'oct': 10,
+    'november': 11, 'nov': 11,
+    'december': 12, 'dec': 12,
+    # French
+    'janvier': 1, 'janv': 1,
+    'fevrier': 2, 'février': 2, 'fevr': 2, 'févr': 2,
+    'mars': 3,
+    'avril': 4, 'avr': 4,
+    'mai': 5,
+    'juin': 6,
+    'juillet': 7, 'juil': 7,
+    'aout': 8, 'août': 8,
+    'septembre': 9,
+    'octobre': 10,
+    'novembre': 11,
+    'decembre': 12, 'décembre': 12, 'déc': 12,
+    # Spanish
+    'enero': 1, 'ene': 1,
+    'febrero': 2,
+    'marzo': 3,
+    'abril': 4, 'abr': 4,
+    'mayo': 5,
+    'junio': 6,
+    'julio': 7,
+    'agosto': 8, 'ago': 8,
+    'septiembre': 9,
+    'octubre': 10,
+    'noviembre': 11,
+    'diciembre': 12, 'dic': 12,
+    # German
+    'januar': 1,
+    'februar': 2,
+    'märz': 3, 'marz': 3, 'mär': 3,
+    'juni': 6,
+    'juli': 7,
+    'oktober': 10, 'okt': 10,
+    'dezember': 12, 'dez': 12,
+    # Italian
+    'gennaio': 1, 'gen': 1,
+    'febbraio': 2,
+    'aprile': 4,
+    'maggio': 5, 'mag': 5,
+    'giugno': 6, 'giu': 6,
+    'luglio': 7, 'lug': 7,
+    'settembre': 9, 'set': 9,
+    'ottobre': 10, 'ott': 10,
+    'dicembre': 12,
+    # Portuguese
+    'janeiro': 1,
+    'fevereiro': 2, 'fev': 2,
+    'marco': 3, 'março': 3,
+    'maio': 5,
+    'junho': 6,
+    'julho': 7,
+    'setembro': 9,
+    'outubro': 10, 'out': 10,
+    'novembro': 11,
+    'dezembro': 12,
+    # Dutch
+    'januari': 1,
+    'februari': 2,
+    'maart': 3, 'mrt': 3,
+    'mei': 5,
+    'augustus': 8,
+    # Danish / Norwegian / Swedish (shared + specific)
+    'marts': 3,  # da
+    'maj': 5,  # da/sv
+    'augusti': 8,  # sv
+    'desember': 12,  # no
+    'des': 12,
+    # Finnish
+    'tammikuu': 1, 'tammi': 1,
+    'helmikuu': 2, 'helmi': 2,
+    'maaliskuu': 3, 'maalis': 3,
+    'huhtikuu': 4, 'huhti': 4,
+    'toukokuu': 5, 'touko': 5,
+    'kesakuu': 6, 'kesäkuu': 6, 'kesa': 6, 'kesä': 6,
+    'heinakuu': 7, 'heinäkuu': 7, 'heina': 7, 'heinä': 7,
+    'elokuu': 8, 'elo': 8,
+    'syyskuu': 9, 'syys': 9,
+    'lokakuu': 10, 'loka': 10,
+    'marraskuu': 11, 'marras': 11,
+    'joulukuu': 12, 'joulu': 12,
+    # Polish
+    'styczen': 1, 'styczeń': 1, 'sty': 1,
+    'luty': 2, 'lut': 2,
+    'marzec': 3,
+    'kwiecien': 4, 'kwiecień': 4, 'kwi': 4,
+    'czerwiec': 6, 'cze': 6,
+    'lipiec': 7,
+    'sierpien': 8, 'sierpień': 8, 'sie': 8,
+    'wrzesien': 9, 'wrzesień': 9, 'wrz': 9,
+    'pazdziernik': 10, 'październik': 10, 'paz': 10, 'paź': 10,
+    # listopad = November in PL/CS (Croatian uses the same word for October;
+    # prefer PL/CS meaning, Croatian October still matches via 'rujan' absence —
+    # use full Croatian-only forms below without overriding listopad)
+    'listopad': 11, 'lis': 11,
+    'grudzien': 12, 'grudzień': 12, 'gru': 12,
+    # Czech
+    'leden': 1, 'led': 1,
+    'unor': 2, 'únor': 2, 'uno': 2,
+    'brezen': 3, 'březen': 3, 'bre': 3,
+    'duben': 4, 'dub': 4,
+    'kveten': 5, 'květen': 5, 'kve': 5,
+    'cerven': 6, 'červen': 6, 'cer': 6,
+    'cervenec': 7, 'červenec': 7, 'cvc': 7,
+    'srpen': 8,
+    'zari': 9, 'září': 9, 'zar': 9,
+    'rijen': 10, 'říjen': 10, 'rij': 10,
+    'prosinec': 12, 'pro': 12,
+    # Slovenian
+    'marec': 3,
+    'junij': 6,
+    'julij': 7,
+    'avgust': 8, 'avg': 8,
+    # Croatian (avoid short forms that collide with PL/CS)
+    'sijecanj': 1, 'siječanj': 1, 'sij': 1,
+    'veljaca': 2, 'veljača': 2, 'velj': 2,
+    'ozujak': 3, 'ozu': 3,
+    'travanj': 4, 'tra': 4,
+    'svibanj': 5, 'svi': 5,
+    'lipanj': 6,
+    'srpanj': 7,
+    'kolovoz': 8, 'kol': 8,
+    'rujan': 9, 'ruj': 9,
+    'studeni': 11, 'stu': 11,
+    'prosinac': 12,
+    # Hungarian
+    'január': 1,
+    'február': 2,
+    'marcius': 3, 'március': 3,
+    'aprilis': 4, 'április': 4,
+    'majus': 5, 'május': 5,
+    'junius': 6, 'június': 6,
+    'julius': 7, 'július': 7,
+    'augusztus': 8,
+    'szeptember': 9, 'sze': 9,
+    'október': 10,
+    # Romanian
+    'ianuarie': 1, 'ian': 1,
+    'februarie': 2,
+    'martie': 3,
+    'aprilie': 4,
+    'iunie': 6, 'iun': 6,
+    'iulie': 7, 'iul': 7,
+    'septembrie': 9,
+    'octombrie': 10,
+    'noiembrie': 11, 'noi': 11,
+    'decembrie': 12,
+    # Turkish
+    'ocak': 1, 'oca': 1,
+    'subat': 2, 'şubat': 2, 'sub': 2, 'şub': 2,
+    'mart': 3,
+    'nisan': 4, 'nis': 4,
+    'mayis': 5, 'mayıs': 5,
+    'haziran': 6, 'haz': 6,
+    'temmuz': 7, 'tem': 7,
+    'agustos': 8, 'ağustos': 8, 'agu': 8, 'ağu': 8,
+    'eylul': 9, 'eylül': 9, 'eyl': 9,
+    'ekim': 10, 'eki': 10,
+    'kasim': 11, 'kasım': 11, 'kas': 11,
+    'aralik': 12, 'aralık': 12, 'ara': 12,
+    # Greek (transliterated scene forms)
+    'ianouarios': 1, 'ian': 1,
+    'fevrouarios': 2,
+    'martios': 3,
+    'aprilios': 4,
+    'maios': 5,
+    'iounios': 6, 'ioun': 6,
+    'ioulios': 7, 'ioul': 7,
+    'avgoustos': 8,
+    'septemvrios': 9,
+    'oktovrios': 10,
+    'noemvrios': 11, 'noe': 11,
+    'dekemvrios': 12, 'dek': 12,
+    # Russian (transliterated)
+    'yanvar': 1, 'yan': 1, 'январь': 1, 'янв': 1,
+    'fevral': 2, 'февраль': 2, 'февр': 2,
+    'апрель': 4, 'апр': 4, 'aprel': 4,
+    'май': 5,
+    'iyun': 6, 'июнь': 6, 'iyn': 6,
+    'iyul': 7, 'июль': 7, 'iyl': 7,
+    'август': 8,
+    'sentyabr': 9, 'сентябрь': 9, 'сент': 9, 'sen': 9,
+    'oktyabr': 10, 'октябрь': 10,
+    'noyabr': 11, 'ноябрь': 11, 'нояб': 11, 'noy': 11,
+    'dekabr': 12, 'декабрь': 12, 'дек': 12,
+    # Japanese / Chinese / Korean numeric month tokens
+    '1月': 1, '2月': 2, '3月': 3, '4月': 4, '5月': 5, '6月': 6,
+    '7月': 7, '8月': 8, '9月': 9, '10月': 10, '11月': 11, '12月': 12,
+    '一月': 1, '二月': 2, '三月': 3, '四月': 4, '五月': 5, '六月': 6,
+    '七月': 7, '八月': 8, '九月': 9, '十月': 10, '十一月': 11, '十二月': 12,
+    '1월': 1, '2월': 2, '3월': 3, '4월': 4, '5월': 5, '6월': 6,
+    '7월': 7, '8월': 8, '9월': 9, '10월': 10, '11월': 11, '12월': 12,
+}
+
+
+def normalize_lang(lang):
+    """Return a 2-letter language code, defaulting to English."""
+    if not lang:
+        return 'en'
+    code = str(lang).replace('-', '_').split('_')[0].lower()
+    code = _LANG_ALIASES.get(code, code)
+    return code or 'en'
+
+
+def strip_accents(value):
+    """Remove diacritics from a unicode string."""
+    normalized = unicodedata.normalize('NFKD', value)
+    return ''.join(char for char in normalized if not unicodedata.combining(char))
+
+
+def month_from_name(name):
+    """Return month number (1-12) for a month name, or None."""
+    if not name:
+        return None
+    key = name.casefold()
+    month = MONTH_NAME_TO_NUMBER.get(key)
+    if month:
+        return month
+    return MONTH_NAME_TO_NUMBER.get(strip_accents(key))
+
+
+def get_month_name(month, lang=None, abbreviated=False):
+    """Return localized month name for search/naming templates.
+
+    :param month: Month number 1-12
+    :param lang: Show/indexer language code (e.g. fr, en, fr_FR)
+    :param abbreviated: Use short form when True
+    :return: Month name string
+    """
+    if not isinstance(month, int) or not 1 <= month <= 12:
+        raise ValueError('month must be an integer from 1 to 12')
+
+    lang_key = normalize_lang(lang)
+    names = MONTH_NAMES_ABBR if abbreviated else MONTH_NAMES_FULL
+    table = names.get(lang_key) or names['en']
+    return table[month]
+
+
+def first_date_of_month(year, month):
+    """Return a placeholder date for month-only releases (day is not the air day).
+
+    Monthly scene packs often omit the day (e.g. Mai.2016). The day value is only a
+    technical placeholder; episode matching must resolve by year+month against the
+    show database (e.g. first Saturday of the month for Le Journal du Hard).
+    """
+    return date(year, month, 1)
+
+
+def month_date_range(year, month):
+    """Return [start, end) dates covering the whole calendar month."""
+    start = date(year, month, 1)
+    if month == 12:
+        end = date(year + 1, 1, 1)
+    else:
+        end = date(year, month + 1, 1)
+    return start, end

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -153,11 +153,11 @@ class NameParser(object):
                 return [], []
 
             indexer_api_params = indexerApi(result.series.indexer).api_params.copy()
+            if result.series.lang:
+                indexer_api_params['language'] = result.series.lang
+
             indexer_api = indexerApi(result.series.indexer).indexer(**indexer_api_params)
             try:
-                if result.series.lang:
-                    indexer_api_params['language'] = result.series.lang
-
                 tv_episode = indexer_api[result.series.indexerid].aired_on(result.air_date)[0]
 
                 season_number = int(tv_episode['seasonnumber'])

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -65,9 +65,10 @@ class NameParser(object):
             [result.series.indexer, result.series.series_id, airdate.toordinal()])
 
         # Month-only scene releases (Mai.2016, 05.2016, ...) do not include the
-        # broadcast day. Day=1 on the guessed date is only a placeholder — shows
-        # like Le Journal du Hard air on the first Saturday of the month.
-        # Resolve by year+month when precision is month.
+        # broadcast day. Day=1 on the guessed date is only a placeholder — the
+        # real episode often airs later in the month.
+        # Prefer year+month when precision is month; also fall back to a month
+        # range when an exact day-1 lookup misses (legacy/placeholder dates).
         month_precision = getattr(result, 'date_precision', None) == 'month'
         if month_precision or (not sql_result and airdate.day == 1):
             from medusa.helper.month_names import month_date_range

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -58,11 +58,41 @@ class NameParser(object):
 
     @staticmethod
     def _get_episodes_by_air_date(result):
-        airdate = result.air_date.toordinal()
+        airdate = result.air_date
         main_db_con = db.DBConnection()
         sql_result = main_db_con.select(
             'SELECT season, episode FROM tv_episodes WHERE indexer = ? AND showid = ? AND airdate = ?',
-            [result.series.indexer, result.series.series_id, airdate])
+            [result.series.indexer, result.series.series_id, airdate.toordinal()])
+
+        # Month-only scene releases (Mai.2016, 05.2016, ...) do not include the
+        # broadcast day. Day=1 on the guessed date is only a placeholder — shows
+        # like Le Journal du Hard air on the first Saturday of the month.
+        # Resolve by year+month when precision is month.
+        month_precision = getattr(result, 'date_precision', None) == 'month'
+        if month_precision or (not sql_result and airdate.day == 1):
+            from medusa.helper.month_names import month_date_range
+            month_start, month_end = month_date_range(airdate.year, airdate.month)
+            month_results = main_db_con.select(
+                'SELECT season, episode FROM tv_episodes '
+                'WHERE indexer = ? AND showid = ? AND airdate >= ? AND airdate < ? '
+                'ORDER BY airdate',
+                [result.series.indexer, result.series.series_id,
+                 month_start.toordinal(), month_end.toordinal()])
+            if len(month_results) == 1:
+                log.debug(
+                    'Resolved month-only release {year}-{month:02d} to episode '
+                    '{season}x{episode} (broadcast day is not the placeholder day)',
+                    {
+                        'year': airdate.year,
+                        'month': airdate.month,
+                        'season': month_results[0]['season'],
+                        'episode': month_results[0]['episode'],
+                    }
+                )
+                return month_results
+            if month_precision:
+                # Ambiguous month (0 or 2+ episodes): do not guess.
+                return []
 
         return sql_result
 
@@ -107,6 +137,19 @@ class NameParser(object):
         if season_number is None or not episode_numbers:
             log.debug('Series {name} has no season or episodes, using indexer',
                       {'name': result.series.name})
+
+            # Month-only releases: the guessed day is not the air day. Prefer DB
+            # month match above; indexer aired_on(exact day) would be wrong.
+            if getattr(result, 'date_precision', None) == 'month':
+                log.warning(
+                    'Unable to find a unique episode in {year}-{month:02d} for series {name}. Skipping',
+                    {
+                        'year': result.air_date.year,
+                        'month': result.air_date.month,
+                        'name': result.series.name,
+                    }
+                )
+                return [], []
 
             indexer_api_params = indexerApi(result.series.indexer).api_params.copy()
             indexer_api = indexerApi(result.series.indexer).indexer(**indexer_api_params)
@@ -518,14 +561,16 @@ class NameParser(object):
                            ab_episode_numbers=helpers.ensure_list(guess.get('absolute_episode')),
                            air_date=guess.get('date'), release_group=guess.get('release_group'),
                            proper_tags=helpers.ensure_list(guess.get('proper_tag')), version=guess.get('version', -1),
-                           episode_details=helpers.ensure_list(guess.get('episode_details')))
+                           episode_details=helpers.ensure_list(guess.get('episode_details')),
+                           date_precision=guess.get('date_precision'))
 
 
 class ParseResult(object):
     """Represent the release information for a given name."""
 
     def __init__(self, guess, series_name=None, season_number=None, episode_numbers=None, ab_episode_numbers=None,
-                 air_date=None, release_group=None, proper_tags=None, version=None, original_name=None, episode_details=None):
+                 air_date=None, release_group=None, proper_tags=None, version=None, original_name=None,
+                 episode_details=None, date_precision=None):
         """Initialize the class.
 
         :param guess:
@@ -550,6 +595,8 @@ class ParseResult(object):
         :type original_name: str
         :param episode_details:
         :type episode_details: list of str
+        :param date_precision:
+        :type date_precision: str or None
         """
         self.original_name = original_name
         self.series_name = series_name
@@ -559,6 +606,7 @@ class ParseResult(object):
         self.quality = self.get_quality(guess)
         self.release_group = release_group
         self.air_date = air_date
+        self.date_precision = date_precision
         self.series = None
         self.version = version
         self.proper_tags = proper_tags

--- a/medusa/name_parser/rules/month_date.py
+++ b/medusa/name_parser/rules/month_date.py
@@ -60,12 +60,14 @@ _TITLE_MONTH_RE = re.compile(
 
 # Month name + year anywhere in the release (spaces or dots), e.g.
 # "Le Journal du Hard Mars 2012 JDH 03 2012" or "Show Name Mai 2016 ..."
-# Require a non-alnum boundary so short tokens like "bre" do not match inside
-# "cembre" (truncated Décembre display glitch).
-# Trailing boundary is any non-alnum so "(Avril-2021)" works (')' after year).
+# Require a non-letter/digit boundary so short tokens like "bre" do not match
+# inside "cembre" (truncated Décembre display glitch). Use Unicode-aware
+# letter/digit classes ([^\W_]) so Cyrillic/CJK month names are not glued to
+# adjacent letters; '_' remains a valid separator.
+# Trailing boundary is end or non-letter/digit so "(Avril-2021)" works.
 _INPUT_MONTH_YEAR_RE = re.compile(
-    r'(?<![A-Za-z0-9])(?P<month>' + _MONTH_NAMES_PATTERN + r')[\s._-]+(?P<year>(?:19|20)\d{2})'
-    r'(?:$|[^A-Za-z0-9])',
+    r'(?<![^\W_])(?P<month>' + _MONTH_NAMES_PATTERN + r')[\s._-]+(?P<year>(?:19|20)\d{2})'
+    r'(?:$|[\W_])',
     re.IGNORECASE,
 )
 

--- a/medusa/name_parser/rules/month_date.py
+++ b/medusa/name_parser/rules/month_date.py
@@ -85,14 +85,15 @@ _MONTH_ONLY_RE = re.compile(
 )
 
 # Numeric monthly packs: MM.YYYY or YYYY.MM with 1 or 2 digit months.
+# Optional spaces around separators cover "(2009 - 10)" style packs.
 # Lookbehind blocks letters/digits/underscore so "Vol_1-2019" and "E02.2010" stay intact.
 # Parenthesized years like "07.(2016)" do not match because '(' is not a date separator.
 _NUMERIC_MONTH_YEAR_RE = re.compile(
     r'(?:^|(?<![0-9A-Za-z_]))'
     r'(?:'
-    r'(?P<m1>0?[1-9]|1[0-2])[._-](?P<y1>(?:19|20)\d{2})'
+    r'(?P<m1>0?[1-9]|1[0-2])\s*[._-]\s*(?P<y1>(?:19|20)\d{2})'
     r'|'
-    r'(?P<y2>(?:19|20)\d{2})[._-](?P<m2>0?[1-9]|1[0-2])'
+    r'(?P<y2>(?:19|20)\d{2})\s*[._-]\s*(?P<m2>0?[1-9]|1[0-2])'
     r')'
     r'(?:[^0-9]|$)'
 )

--- a/medusa/name_parser/rules/month_date.py
+++ b/medusa/name_parser/rules/month_date.py
@@ -162,6 +162,45 @@ def _safe_removes(matches, match_list):
     return safe
 
 
+def _path_segments(input_string):
+    """Split a release name into path segments, closest to the file first.
+
+    Library items are parsed as full paths, so the month/year token and a
+    season folder can live in different segments.
+    """
+    segments = []
+    start = 0
+    for index, char in enumerate(input_string or ''):
+        if char in '\\/':
+            if index > start:
+                segments.append((start, input_string[start:index]))
+            start = index + 1
+    if input_string and start < len(input_string):
+        segments.append((start, input_string[start:]))
+    return list(reversed(segments))
+
+
+def _segment_has_sxxexx(sxxexx_matches, offset, segment):
+    end = offset + len(segment)
+    return any(match.start < end and match.end > offset for match in sxxexx_matches)
+
+
+def _search_segments(regex, segments, sxxexx_matches, allow_sxxexx=False):
+    """Search segments for a month/year pattern, skipping SxxExx segments.
+
+    A season folder (Show S35/Show 01-2026.mkv) must not prevent the file name
+    from being read as a monthly release, so SxxExx only blocks the segment it
+    belongs to.
+    """
+    for offset, segment in segments:
+        if not allow_sxxexx and _segment_has_sxxexx(sxxexx_matches, offset, segment):
+            continue
+        found = regex.search(segment)
+        if found:
+            return offset, segment, found
+    return None, None, None
+
+
 class CreateDateFromMonthYearRelease(Rule):
     """Create a date from MonthName.YYYY or MM.YYYY / YYYY.MM monthly releases.
 
@@ -234,10 +273,12 @@ class CreateDateFromMonthYearRelease(Rule):
         seasons = matches.named('season')
         episodes = matches.named('episode')
         absolute_episodes = matches.named('absolute_episode') or []
-        has_sxxexx = any(
-            'SxxExx' in (match.tags or [])
+        sxxexx_matches = [
+            match
             for match in (seasons or []) + (episodes or [])
-        )
+            if 'SxxExx' in (match.tags or [])
+        ]
+        segments = _path_segments(input_string)
         # Dash monthly packs like "(02-2021)" / "07-2025" are mis-parsed by
         # guessit as SxxExx with a season equal to the year (season=2021,
         # episode=2). A season whose value is a plausible year is the tell:
@@ -256,80 +297,77 @@ class CreateDateFromMonthYearRelease(Rule):
         # Handles space-separated names and packs with trailing junk / JDH tags,
         # e.g. "Le Journal du Hard Mars 2012 JDH 03 2012 avi"
         # Truncated display glitches (Ao/cembre/vrier) are intentionally ignored.
-        if input_string and not has_sxxexx:
-            named = _INPUT_MONTH_YEAR_RE.search(input_string)
-            if named:
-                month = month_from_name(named.group('month'))
-                year = int(named.group('year'))
-                if month and _is_valid_year(year):
-                    to_remove.extend(years or [])
-                    to_remove.extend(seasons or [])
-                    to_remove.extend(episodes or [])
-                    to_remove.extend(absolute_episodes)
-                    if titles:
-                        # Keep title text before the month token when possible.
-                        # Drop any directory components so full paths do not
-                        # leak into the title (\\server\...\Show\Show Name).
-                        prefix = input_string[:named.start('month')]
-                        prefix = re.split(r'[\\/]', prefix)[-1]
-                        # Drop leading bracketed release tags: [CANAL+], [JDH], ...
-                        prefix = re.sub(r'^\s*(?:[\[(][^\])]*[\])][\s._-]*)+', '', prefix)
-                        # Drop a redundant numeric year/month right before the
-                        # month name (…2022.07.Juillet.2022…)
-                        prefix = re.sub(r'(?:19|20)\d{2}[\s._-]+\d{1,2}[\s._-]*$', '', prefix)
-                        prefix = prefix.strip(' .-_([')
-                        if prefix:
-                            cleaned = re.sub(r'[\s._-]+', ' ', prefix).strip(' .-_([')
-                            if cleaned:
-                                new_title = copy.copy(titles[0])
-                                new_title.value = cleaned
-                                to_remove.extend(titles)
-                                to_append.append(new_title)
+        offset, segment, named = _search_segments(_INPUT_MONTH_YEAR_RE, segments, sxxexx_matches)
+        if named:
+            month = month_from_name(named.group('month'))
+            year = int(named.group('year'))
+            if month and _is_valid_year(year):
+                to_remove.extend(years or [])
+                to_remove.extend(seasons or [])
+                to_remove.extend(episodes or [])
+                to_remove.extend(absolute_episodes)
+                if titles:
+                    # Keep title text before the month token, taken from the
+                    # matched segment so directory components of a full path
+                    # do not leak into the title.
+                    prefix = segment[:named.start('month')]
+                    # Drop leading bracketed release tags: [CANAL+], [JDH], ...
+                    prefix = re.sub(r'^\s*(?:[\[(][^\])]*[\])][\s._-]*)+', '', prefix)
+                    # Drop a redundant numeric year/month right before the
+                    # month name (…2022.07.Juillet.2022…)
+                    prefix = re.sub(r'(?:19|20)\d{2}[\s._-]+\d{1,2}[\s._-]*$', '', prefix)
+                    prefix = prefix.strip(' .-_([')
+                    if prefix:
+                        cleaned = re.sub(r'[\s._-]+', ' ', prefix).strip(' .-_([')
+                        if cleaned:
+                            new_title = copy.copy(titles[0])
+                            new_title.value = cleaned
+                            to_remove.extend(titles)
+                            to_append.append(new_title)
 
-                    self._append_month_precision_date(
-                        to_append,
-                        named.start('month'),
-                        named.end('year'),
-                        year,
-                        month,
-                        input_string,
-                    )
-                    return _safe_removes(matches, to_remove), to_append
+                self._append_month_precision_date(
+                    to_append,
+                    offset + named.start('month'),
+                    offset + named.end('year'),
+                    year,
+                    month,
+                    input_string,
+                )
+                return _safe_removes(matches, to_remove), to_append
 
         # --- Pattern 0b: JDH MM YYYY / MM-YY / JDH122022 scene tags ------------
-        if input_string and not has_sxxexx:
-            jdh = _JDH_MONTH_YEAR_RE.search(input_string)
-            if jdh:
-                month = int(jdh.group('month'))
-                year = _parse_year(jdh.group('year'))
-                if year is not None and _is_valid_year(year):
-                    to_remove.extend(years or [])
-                    to_remove.extend(seasons or [])
-                    to_remove.extend(episodes or [])
-                    to_remove.extend(absolute_episodes)
-                    if titles:
-                        # Compact packs glue the tag to the month (JDH04-2022):
-                        # the guessed title then swallows the month digits.
-                        # Truncate it at the month start (JDH04 -> JDH).
-                        title = titles[0]
-                        month_start = jdh.start('month')
-                        if title.start < month_start <= title.end:
-                            cleaned = input_string[title.start:month_start]
-                            cleaned = re.sub(r'[\s._-]+', ' ', cleaned).strip(' .-_([')
-                            if cleaned:
-                                new_title = copy.copy(title)
-                                new_title.value = cleaned
-                                to_remove.extend(titles)
-                                to_append.append(new_title)
-                    self._append_month_precision_date(
-                        to_append,
-                        jdh.start('month'),
-                        jdh.end('year'),
-                        year,
-                        month,
-                        input_string,
-                    )
-                    return _safe_removes(matches, to_remove), to_append
+        offset, segment, jdh = _search_segments(_JDH_MONTH_YEAR_RE, segments, sxxexx_matches)
+        if jdh:
+            month = int(jdh.group('month'))
+            year = _parse_year(jdh.group('year'))
+            if year is not None and _is_valid_year(year):
+                month_start = offset + jdh.start('month')
+                to_remove.extend(years or [])
+                to_remove.extend(seasons or [])
+                to_remove.extend(episodes or [])
+                to_remove.extend(absolute_episodes)
+                if titles:
+                    # Compact packs glue the tag to the month (JDH04-2022):
+                    # the guessed title then swallows the month digits.
+                    # Truncate it at the month start (JDH04 -> JDH).
+                    title = titles[0]
+                    if title.start < month_start <= title.end:
+                        cleaned = input_string[title.start:month_start]
+                        cleaned = re.sub(r'[\s._-]+', ' ', cleaned).strip(' .-_([')
+                        if cleaned:
+                            new_title = copy.copy(title)
+                            new_title.value = cleaned
+                            to_remove.extend(titles)
+                            to_append.append(new_title)
+                self._append_month_precision_date(
+                    to_append,
+                    month_start,
+                    offset + jdh.end('year'),
+                    year,
+                    month,
+                    input_string,
+                )
+                return _safe_removes(matches, to_remove), to_append
 
         # --- Pattern 1: title ends with month name + year match ---------------
         if years and titles:
@@ -366,12 +404,11 @@ class CreateDateFromMonthYearRelease(Rule):
         # --- Pattern 2: adjacent MM.YYYY or YYYY.MM (1 or 2 digit month) ------
         # Skip real SxxExx and anime absolute-episode packs (e.g. Show.-.5.2016),
         # but still handle dash monthly packs mis-parsed as season==year.
-        if (
-            input_string
-            and (not has_sxxexx or season_looks_like_year)
-            and (not has_anime_absolute or season_looks_like_year)
-        ):
-            numeric = _NUMERIC_MONTH_YEAR_RE.search(input_string)
+        if not has_anime_absolute or season_looks_like_year:
+            offset, segment, numeric = _search_segments(
+                _NUMERIC_MONTH_YEAR_RE, segments, sxxexx_matches,
+                allow_sxxexx=season_looks_like_year,
+            )
             if numeric:
                 if numeric.group('y1'):
                     year = int(numeric.group('y1'))
@@ -395,8 +432,8 @@ class CreateDateFromMonthYearRelease(Rule):
 
                     self._append_month_precision_date(
                         to_append,
-                        span_start,
-                        span_end,
+                        offset + span_start,
+                        offset + span_end,
                         year,
                         month,
                         input_string,
@@ -409,30 +446,32 @@ class CreateDateFromMonthYearRelease(Rule):
         # by the regex.
         # Years 01-12 are ambiguous with episode ranges (02-03, 1-12) — skip
         # those here; JDH-prefixed packs still use pattern 0b.
-        if input_string and (not has_sxxexx or season_looks_like_year):
-            short = _NUMERIC_MONTH_SHORT_YEAR_RE.search(input_string)
-            if short:
-                month = int(short.group('month'))
-                year_token = short.group('year')
-                year = _parse_year(year_token)
-                if (
-                    year is not None
-                    and _is_valid_year(year)
-                    and int(year_token) > 12
-                ):
-                    to_remove.extend(seasons or [])
-                    to_remove.extend(episodes or [])
-                    to_remove.extend(years or [])
-                    to_remove.extend(absolute_episodes)
-                    self._append_month_precision_date(
-                        to_append,
-                        short.start('month'),
-                        short.end('year'),
-                        year,
-                        month,
-                        input_string,
-                    )
-                    return _safe_removes(matches, to_remove), to_append
+        offset, segment, short = _search_segments(
+            _NUMERIC_MONTH_SHORT_YEAR_RE, segments, sxxexx_matches,
+            allow_sxxexx=season_looks_like_year,
+        )
+        if short:
+            month = int(short.group('month'))
+            year_token = short.group('year')
+            year = _parse_year(year_token)
+            if (
+                year is not None
+                and _is_valid_year(year)
+                and int(year_token) > 12
+            ):
+                to_remove.extend(seasons or [])
+                to_remove.extend(episodes or [])
+                to_remove.extend(years or [])
+                to_remove.extend(absolute_episodes)
+                self._append_month_precision_date(
+                    to_append,
+                    offset + short.start('month'),
+                    offset + short.end('year'),
+                    year,
+                    month,
+                    input_string,
+                )
+                return _safe_removes(matches, to_remove), to_append
 
         # --- Pattern 3: day + month name in episode_title, year elsewhere ------
         episode_titles = matches.named('episode_title')

--- a/medusa/name_parser/rules/month_date.py
+++ b/medusa/name_parser/rules/month_date.py
@@ -1,0 +1,471 @@
+# coding=utf-8
+"""Rules to create air dates from month/year release patterns.
+
+Handles scene releases for monthly shows that use a month name or month number
+with a year instead of a full YYYY.MM.DD date, for example:
+
+  Show.Name.Mai.2016...
+  Show.Name.August.2017...
+  Show.Name.08.1998
+  Show.Name.10.2024
+  Show.Name.2011.01...
+
+Day is set to 1 only as a technical placeholder when the release has no day.
+That is NOT the broadcast day (e.g. Le Journal du Hard airs on the first
+Saturday of the month). Matching must resolve the real episode by year+month.
+"""
+from __future__ import unicode_literals
+
+import copy
+import re
+from datetime import date
+
+from medusa.helper.month_names import MONTH_NAME_TO_NUMBER, first_date_of_month, month_from_name
+
+from rebulk.match import Match
+from rebulk.processors import POST_PROCESS
+from rebulk.rules import AppendMatch, Consequence, Rule
+
+
+class SafeRemoveMatch(Consequence):
+    """Like RemoveMatch, but tolerate rebulk dict/list inconsistency.
+
+    Full paths that repeat the same token (folder + file) can leave equal
+    episode matches in the delegate list while already absent from name_dict.
+    Stock RemoveMatch then raises ValueError inside list.remove.
+    """
+
+    def then(self, matches, when_response, context):  # pylint: disable=unused-argument
+        if when_response is None:
+            return
+        if not isinstance(when_response, (list, tuple)):
+            when_response = [when_response]
+        for match in list(when_response):
+            try:
+                if match in matches:
+                    matches.remove(match)
+            except ValueError:
+                continue
+
+
+_MONTH_NAMES_PATTERN = '|'.join(
+    sorted((re.escape(name) for name in MONTH_NAME_TO_NUMBER), key=len, reverse=True)
+)
+
+# Title ending with a month name: "Show Name Mai" / "Show Name August"
+_TITLE_MONTH_RE = re.compile(
+    r'^(?P<title>.+?)(?:[\s._-]+)(?P<month>' + _MONTH_NAMES_PATTERN + r')$',
+    re.IGNORECASE,
+)
+
+# Month name + year anywhere in the release (spaces or dots), e.g.
+# "Le Journal du Hard Mars 2012 JDH 03 2012" or "Show Name Mai 2016 ..."
+# Require a non-alnum boundary so short tokens like "bre" do not match inside
+# "cembre" (truncated Décembre display glitch).
+# Trailing boundary is any non-alnum so "(Avril-2021)" works (')' after year).
+_INPUT_MONTH_YEAR_RE = re.compile(
+    r'(?<![A-Za-z0-9])(?P<month>' + _MONTH_NAMES_PATTERN + r')[\s._-]+(?P<year>(?:19|20)\d{2})'
+    r'(?:$|[^A-Za-z0-9])',
+    re.IGNORECASE,
+)
+
+# Scene tag: JDH 03 2012 / JDH-01-24 / JDH09-21 / JDH122022
+_JDH_MONTH_YEAR_RE = re.compile(
+    r'(?i)(?:^|[\s._\[(-])JDH[\s._-]*(?P<month>0?[1-9]|1[0-2])[\s._-]*'
+    r'(?P<year>(?:19|20)\d{2}|\d{2})'
+    r'(?:$|[^A-Za-z0-9])',
+)
+
+# Episode title that is only a month name (e.g. "3.aout" -> episode_title=aout)
+_MONTH_ONLY_RE = re.compile(
+    r'^(' + _MONTH_NAMES_PATTERN + r')$',
+    re.IGNORECASE,
+)
+
+# Numeric monthly packs: MM.YYYY or YYYY.MM with 1 or 2 digit months.
+# Lookbehind blocks letters/digits/underscore so "Vol_1-2019" and "E02.2010" stay intact.
+# Parenthesized years like "07.(2016)" do not match because '(' is not a date separator.
+_NUMERIC_MONTH_YEAR_RE = re.compile(
+    r'(?:^|(?<![0-9A-Za-z_]))'
+    r'(?:'
+    r'(?P<m1>0?[1-9]|1[0-2])[._-](?P<y1>(?:19|20)\d{2})'
+    r'|'
+    r'(?P<y2>(?:19|20)\d{2})[._-](?P<m2>0?[1-9]|1[0-2])'
+    r')'
+    r'(?:[^0-9]|$)'
+)
+
+# Dash-only MM-YY (2-digit year). Dots are excluded so weak pairs like
+# "Show.Name.09.10" stay episodes, not month/year.
+_NUMERIC_MONTH_SHORT_YEAR_RE = re.compile(
+    r'(?:^|(?<![0-9A-Za-z_]))'
+    r'(?P<month>0?[1-9]|1[0-2])-(?P<year>\d{2})'
+    r'(?:$|[^0-9])'
+)
+
+
+def _is_valid_year(year):
+    return 1920 <= year <= 2100
+
+
+def _parse_year(year_value):
+    """Parse a 2- or 4-digit year string/int into a full year.
+
+    Two-digit years use pivot 50: 00-50 -> 2000-2050, 51-99 -> 1951-1999
+    (covers Journal du Hard from the early 1990s and current packs).
+    """
+    if isinstance(year_value, int):
+        year_str = str(year_value)
+    else:
+        year_str = str(year_value or '')
+    if len(year_str) == 2 and year_str.isdigit():
+        yy = int(year_str)
+        return 2000 + yy if yy <= 50 else 1900 + yy
+    if year_str.isdigit():
+        return int(year_str)
+    return None
+
+
+def _single_int(value):
+    if isinstance(value, list):
+        if len(value) != 1:
+            return None
+        value = value[0]
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _unique_matches(match_list):
+    """Deduplicate match objects for RemoveMatch.
+
+    Rebulk Match equality is span/value/name/parent based, not identity.
+    Passing two equal matches to RemoveMatch makes the second list.remove fail.
+    """
+    unique = []
+    for match in match_list or []:
+        if match is None:
+            continue
+        if match not in unique:
+            unique.append(match)
+    return unique
+
+
+def _safe_removes(matches, match_list):
+    """Deduplicate and keep only matches still present in the Matches object."""
+    safe = []
+    for match in _unique_matches(match_list):
+        if match in matches:
+            safe.append(match)
+    return safe
+
+
+class CreateDateFromMonthYearRelease(Rule):
+    """Create a date from MonthName.YYYY or MM.YYYY / YYYY.MM monthly releases.
+
+    guessit -t episode "Show.Name.Mai.2016.HDTV.x264-GROUP"
+
+    without this fix:
+        {
+            "title": "Show Name Mai",
+            "year": 2016,
+            "type": "episode"
+        }
+
+    with this fix:
+        {
+            "title": "Show Name",
+            "date": "2016-05-01",
+            "date_precision": "month",
+            "type": "episode"
+        }
+
+    The date day is only a placeholder. Air-by-date matching uses year+month
+    (date_precision=month), because monthly shows may air on another day
+    (e.g. first Saturday of the month).
+
+    Also converts weak year-as-season patterns (not SxxExx):
+      Show.Name.10.2024 -> date 2024-10-01
+      Show.Name.2011.01 -> date 2011-01-01
+    """
+
+    priority = POST_PROCESS
+    consequence = [SafeRemoveMatch, AppendMatch]
+
+    @staticmethod
+    def _append_month_precision_date(to_append, start, end, year, month, input_string):
+        """Append date + date_precision matches for a month-only release."""
+        to_append.append(Match(
+            start,
+            end,
+            name='date',
+            value=first_date_of_month(year, month),
+            input_string=input_string,
+            tags=['month-year-date'],
+        ))
+        to_append.append(Match(
+            start,
+            end,
+            name='date_precision',
+            value='month',
+            input_string=input_string,
+            tags=['month-year-date'],
+        ))
+
+    def when(self, matches, context):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        """Evaluate the rule.
+
+        :param matches:
+        :type matches: rebulk.match.Matches
+        :param context:
+        :type context: dict
+        :return:
+        """
+        if matches.named('date'):
+            return
+
+        to_remove = []
+        to_append = []
+        input_string = matches.input_string
+        years = matches.named('year')
+        titles = matches.named('title')
+        seasons = matches.named('season')
+        episodes = matches.named('episode')
+        absolute_episodes = matches.named('absolute_episode') or []
+        has_sxxexx = any(
+            'SxxExx' in (match.tags or [])
+            for match in (seasons or []) + (episodes or [])
+        )
+        # Dash monthly packs like "(02-2021)" / "07-2025" are mis-parsed by
+        # guessit as SxxExx with a season equal to the year (season=2021,
+        # episode=2). A season whose value is a plausible year is the tell:
+        # real seasons are small, so this never matches genuine SxxExx (S35E01).
+        season_looks_like_year = any(
+            _is_valid_year(value)
+            for value in (_single_int(match.value) for match in (seasons or []))
+            if value is not None
+        )
+        has_anime_absolute = any(
+            'anime' in (match.tags or [])
+            for match in absolute_episodes
+        )
+
+        # --- Pattern 0a: MonthName + YYYY in the raw release string -----------
+        # Handles space-separated names and packs with trailing junk / JDH tags,
+        # e.g. "Le Journal du Hard Mars 2012 JDH 03 2012 avi"
+        # Truncated display glitches (Ao/cembre/vrier) are intentionally ignored.
+        if input_string and not has_sxxexx:
+            named = _INPUT_MONTH_YEAR_RE.search(input_string)
+            if named:
+                month = month_from_name(named.group('month'))
+                year = int(named.group('year'))
+                if month and _is_valid_year(year):
+                    to_remove.extend(years or [])
+                    to_remove.extend(seasons or [])
+                    to_remove.extend(episodes or [])
+                    to_remove.extend(absolute_episodes)
+                    if titles:
+                        # Keep title text before the month token when possible.
+                        # Drop any directory components so full paths do not
+                        # leak into the title (\\server\...\Show\Show Name).
+                        prefix = input_string[:named.start('month')]
+                        prefix = re.split(r'[\\/]', prefix)[-1]
+                        # Drop leading bracketed release tags: [CANAL+], [JDH], ...
+                        prefix = re.sub(r'^\s*(?:[\[(][^\])]*[\])][\s._-]*)+', '', prefix)
+                        # Drop a redundant numeric year/month right before the
+                        # month name (…2022.07.Juillet.2022…)
+                        prefix = re.sub(r'(?:19|20)\d{2}[\s._-]+\d{1,2}[\s._-]*$', '', prefix)
+                        prefix = prefix.strip(' .-_([')
+                        if prefix:
+                            cleaned = re.sub(r'[\s._-]+', ' ', prefix).strip(' .-_([')
+                            if cleaned:
+                                new_title = copy.copy(titles[0])
+                                new_title.value = cleaned
+                                to_remove.extend(titles)
+                                to_append.append(new_title)
+
+                    self._append_month_precision_date(
+                        to_append,
+                        named.start('month'),
+                        named.end('year'),
+                        year,
+                        month,
+                        input_string,
+                    )
+                    return _safe_removes(matches, to_remove), to_append
+
+        # --- Pattern 0b: JDH MM YYYY / MM-YY / JDH122022 scene tags ------------
+        if input_string and not has_sxxexx:
+            jdh = _JDH_MONTH_YEAR_RE.search(input_string)
+            if jdh:
+                month = int(jdh.group('month'))
+                year = _parse_year(jdh.group('year'))
+                if year is not None and _is_valid_year(year):
+                    to_remove.extend(years or [])
+                    to_remove.extend(seasons or [])
+                    to_remove.extend(episodes or [])
+                    to_remove.extend(absolute_episodes)
+                    if titles:
+                        # Compact packs glue the tag to the month (JDH04-2022):
+                        # the guessed title then swallows the month digits.
+                        # Truncate it at the month start (JDH04 -> JDH).
+                        title = titles[0]
+                        month_start = jdh.start('month')
+                        if title.start < month_start <= title.end:
+                            cleaned = input_string[title.start:month_start]
+                            cleaned = re.sub(r'[\s._-]+', ' ', cleaned).strip(' .-_([')
+                            if cleaned:
+                                new_title = copy.copy(title)
+                                new_title.value = cleaned
+                                to_remove.extend(titles)
+                                to_append.append(new_title)
+                    self._append_month_precision_date(
+                        to_append,
+                        jdh.start('month'),
+                        jdh.end('year'),
+                        year,
+                        month,
+                        input_string,
+                    )
+                    return _safe_removes(matches, to_remove), to_append
+
+        # --- Pattern 1: title ends with month name + year match ---------------
+        if years and titles:
+            year_match = years[0]
+            year = _single_int(year_match.value)
+            if year is not None and _is_valid_year(year):
+                for title in titles:
+                    month_match = _TITLE_MONTH_RE.match(title.value)
+                    if not month_match:
+                        continue
+                    month = month_from_name(month_match.group('month'))
+                    if not month:
+                        continue
+
+                    new_title = copy.copy(title)
+                    new_title.value = month_match.group('title').strip(' .-_')
+                    to_remove.append(title)
+                    to_append.append(new_title)
+
+                    to_remove.extend(years)
+                    to_remove.extend(matches.named('season'))
+                    to_remove.extend(matches.named('episode'))
+
+                    self._append_month_precision_date(
+                        to_append,
+                        year_match.start,
+                        year_match.end,
+                        year,
+                        month,
+                        year_match.input_string,
+                    )
+                    return _safe_removes(matches, to_remove), to_append
+
+        # --- Pattern 2: adjacent MM.YYYY or YYYY.MM (1 or 2 digit month) ------
+        # Skip real SxxExx and anime absolute-episode packs (e.g. Show.-.5.2016),
+        # but still handle dash monthly packs mis-parsed as season==year.
+        if (
+            input_string
+            and (not has_sxxexx or season_looks_like_year)
+            and (not has_anime_absolute or season_looks_like_year)
+        ):
+            numeric = _NUMERIC_MONTH_YEAR_RE.search(input_string)
+            if numeric:
+                if numeric.group('y1'):
+                    year = int(numeric.group('y1'))
+                    month = int(numeric.group('m1'))
+                else:
+                    year = int(numeric.group('y2'))
+                    month = int(numeric.group('m2'))
+
+                if _is_valid_year(year):
+                    to_remove.extend(seasons or [])
+                    to_remove.extend(episodes or [])
+                    to_remove.extend(years or [])
+                    to_remove.extend(matches.named('absolute_episode'))
+
+                    if numeric.group('y1'):
+                        span_start = numeric.start('m1')
+                        span_end = numeric.end('y1')
+                    else:
+                        span_start = numeric.start('y2')
+                        span_end = numeric.end('m2')
+
+                    self._append_month_precision_date(
+                        to_append,
+                        span_start,
+                        span_end,
+                        year,
+                        month,
+                        input_string,
+                    )
+                    return _safe_removes(matches, to_remove), to_append
+
+        # --- Pattern 2b: dash-only MM-YY (2-digit year) -----------------------
+        # guessit often turns "09-24" into an episode range; allow past anime
+        # absolute tags. Real SxxExx still blocked. Dot pairs (09.10) excluded
+        # by the regex.
+        # Years 01-12 are ambiguous with episode ranges (02-03, 1-12) — skip
+        # those here; JDH-prefixed packs still use pattern 0b.
+        if input_string and (not has_sxxexx or season_looks_like_year):
+            short = _NUMERIC_MONTH_SHORT_YEAR_RE.search(input_string)
+            if short:
+                month = int(short.group('month'))
+                year_token = short.group('year')
+                year = _parse_year(year_token)
+                if (
+                    year is not None
+                    and _is_valid_year(year)
+                    and int(year_token) > 12
+                ):
+                    to_remove.extend(seasons or [])
+                    to_remove.extend(episodes or [])
+                    to_remove.extend(years or [])
+                    to_remove.extend(absolute_episodes)
+                    self._append_month_precision_date(
+                        to_append,
+                        short.start('month'),
+                        short.end('year'),
+                        year,
+                        month,
+                        input_string,
+                    )
+                    return _safe_removes(matches, to_remove), to_append
+
+        # --- Pattern 3: day + month name in episode_title, year elsewhere ------
+        episode_titles = matches.named('episode_title')
+        if years and episodes and episode_titles:
+            year = _single_int(years[0].value)
+            day = _single_int(episodes[0].value)
+            month_title = episode_titles[0]
+            month = None
+            if _MONTH_ONLY_RE.match(str(month_title.value or '')):
+                month = month_from_name(month_title.value)
+
+            if (
+                year is not None
+                and _is_valid_year(year)
+                and day is not None
+                and 1 <= day <= 31
+                and month is not None
+            ):
+                try:
+                    parsed = date(year, month, day)
+                except ValueError:
+                    parsed = None
+                if parsed:
+                    to_remove.extend(years)
+                    to_remove.extend(episodes)
+                    to_remove.extend(episode_titles)
+                    to_remove.extend(seasons)
+                    to_append.append(Match(
+                        years[0].start,
+                        years[0].end,
+                        name='date',
+                        value=parsed,
+                        input_string=years[0].input_string,
+                        tags=['month-year-date'],
+                    ))
+                    return _safe_removes(matches, to_remove), to_append
+
+        return

--- a/medusa/name_parser/rules/month_date.py
+++ b/medusa/name_parser/rules/month_date.py
@@ -98,12 +98,15 @@ _NUMERIC_MONTH_YEAR_RE = re.compile(
     r'(?:[^0-9]|$)'
 )
 
-# Dash-only MM-YY (2-digit year). Dots are excluded so weak pairs like
-# "Show.Name.09.10" stay episodes, not month/year.
+# MM-YY (dash) or MM.YY (dot, 2-digit year). Trailing for dots rejects another
+# dotted number (show titles like 11.22.63) but still allows .mkv extensions.
 _NUMERIC_MONTH_SHORT_YEAR_RE = re.compile(
     r'(?:^|(?<![0-9A-Za-z_]))'
-    r'(?P<month>0?[1-9]|1[0-2])-(?P<year>\d{2})'
-    r'(?:$|[^0-9])'
+    r'(?:'
+    r'(?P<month>0?[1-9]|1[0-2])-(?P<year>\d{2})(?:$|[^0-9])'
+    r'|'
+    r'(?P<month_dot>0?[1-9]|1[0-2])\.(?P<year_dot>\d{2})(?:$|[^0-9.]|\.[A-Za-z])'
+    r')'
 )
 
 
@@ -441,24 +444,32 @@ class CreateDateFromMonthYearRelease(Rule):
                     )
                     return _safe_removes(matches, to_remove), to_append
 
-        # --- Pattern 2b: dash-only MM-YY (2-digit year) -----------------------
-        # guessit often turns "09-24" into an episode range; allow past anime
-        # absolute tags. Real SxxExx still blocked. Dot pairs (09.10) excluded
-        # by the regex.
-        # Years 01-12 are ambiguous with episode ranges (02-03, 1-12) — skip
-        # those here; JDH-prefixed packs still use pattern 0b.
+        # --- Pattern 2b: MM-YY / MM.YY (2-digit year) -------------------------
+        # guessit often turns "09-24" / "09.24" into an episode or range.
+        # Real SxxExx still blocked per segment. Years 01-12 stay ambiguous
+        # with episode ranges (02-03, 09.10) — skip those; JDH tags use 0b.
         offset, segment, short = _search_segments(
             _NUMERIC_MONTH_SHORT_YEAR_RE, segments, sxxexx_matches,
             allow_sxxexx=season_looks_like_year,
         )
         if short:
-            month = int(short.group('month'))
-            year_token = short.group('year')
+            if short.group('year_dot') is not None:
+                month = int(short.group('month_dot'))
+                year_token = short.group('year_dot')
+                # Dots: require YY >= 16 so episode pairs (12.13, 09.10) stay intact.
+                min_yy = 16
+                span_month, span_year = 'month_dot', 'year_dot'
+            else:
+                month = int(short.group('month'))
+                year_token = short.group('year')
+                # Dashes: YY > 12 (packs like 09-24).
+                min_yy = 13
+                span_month, span_year = 'month', 'year'
             year = _parse_year(year_token)
             if (
                 year is not None
                 and _is_valid_year(year)
-                and int(year_token) > 12
+                and int(year_token) >= min_yy
             ):
                 to_remove.extend(seasons or [])
                 to_remove.extend(episodes or [])
@@ -466,8 +477,8 @@ class CreateDateFromMonthYearRelease(Rule):
                 to_remove.extend(absolute_episodes)
                 self._append_month_precision_date(
                     to_append,
-                    offset + short.start('month'),
-                    offset + short.end('year'),
+                    offset + short.start(span_month),
+                    offset + short.end(span_year),
                     year,
                     month,
                     input_string,

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -35,6 +35,8 @@ import re
 from guessit.rules.common.comparators import marker_sorted
 from guessit.rules.common.formatters import cleanup
 
+from medusa.name_parser.rules.month_date import CreateDateFromMonthYearRelease
+
 from rebulk.processors import POST_PROCESS
 from rebulk.rebulk import Rebulk
 from rebulk.rules import AppendMatch, RemoveMatch, RenameMatch, Rule
@@ -2014,6 +2016,8 @@ def rules():
         CreateAliasWithCountryOrYear,
         FixTitlesThatExistOfAbsoluteEpisodeNumbers,
         FixTitlesThatExistOfYearNumbers,
+        # After absolute/season cleanup: monthly MonthName.YYYY / MM.YYYY releases
+        CreateDateFromMonthYearRelease,
         ReleaseGroupPostProcessor,
         FixParentFolderReplacingTitle,
         FixMultipleSources,

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -714,13 +714,18 @@ class PostProcessor(object):
 
         if parse_result.series and all([parse_result.series.air_by_date or parse_result.series.is_sports,
                                         parse_result.is_air_by_date]):
-            if parse_result.date_precision == 'month' and parse_result.episode_numbers:
-                # Month-only release (e.g. JDH-01-2023): NameParser already
-                # resolved the real episode by year+month. An exact-airdate
-                # lookup on the placeholder day 1 would fail whenever the
-                # episode airs later in the month.
-                season = parse_result.season_number
-                episodes = parse_result.episode_numbers
+            if parse_result.date_precision == 'month':
+                if parse_result.episode_numbers:
+                    # Month-only release: NameParser already resolved the real
+                    # episode by year+month. An exact-airdate lookup on the
+                    # placeholder day 1 would fail when airing is later.
+                    season = parse_result.season_number
+                    episodes = parse_result.episode_numbers
+                else:
+                    # Ambiguous/unresolved month: fail cleanly instead of
+                    # retrying the placeholder day-1 airdate conversion.
+                    season = None
+                    episodes = []
             else:
                 season = -1
                 episodes = [parse_result.air_date]

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -714,8 +714,16 @@ class PostProcessor(object):
 
         if parse_result.series and all([parse_result.series.air_by_date or parse_result.series.is_sports,
                                         parse_result.is_air_by_date]):
-            season = -1
-            episodes = [parse_result.air_date]
+            if parse_result.date_precision == 'month' and parse_result.episode_numbers:
+                # Month-only release (e.g. JDH-01-2023): NameParser already
+                # resolved the real episode by year+month. An exact-airdate
+                # lookup on the placeholder day 1 would fail whenever the
+                # episode airs later in the month.
+                season = parse_result.season_number
+                episodes = parse_result.episode_numbers
+            else:
+                season = -1
+                episodes = [parse_result.air_date]
         else:
             season = parse_result.season_number
             episodes = parse_result.episode_numbers

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -62,6 +62,7 @@ from medusa.helper.exceptions import (
     NoNFOException,
     ex,
 )
+from medusa.helper.month_names import get_month_name
 from medusa.indexers.api import indexerApi
 from medusa.indexers.config import indexerConfig
 from medusa.indexers.exceptions import (
@@ -1603,10 +1604,11 @@ class Episode(TV):
             '%A_D': us(str(self.airdate)),
             '%A-D': str(self.airdate),
             '%Y': str(self.airdate.year),
+            '%y': '%02d' % (self.airdate.year % 100),
             '%M': str(self.airdate.month),
             '%D': str(self.airdate.day),
-            '%Mm': str(self.airdate.strftime('%b')),
-            '%MM': str(self.airdate.strftime('%B')),
+            '%Mm': get_month_name(self.airdate.month, self.series.lang, abbreviated=True),
+            '%MM': get_month_name(self.airdate.month, self.series.lang, abbreviated=False),
             '%CY': str(date.today().year),
             '%CM': str(date.today().month),
             '%CD': str(date.today().day),

--- a/tests/helper/test_month_names.py
+++ b/tests/helper/test_month_names.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+"""Tests for month name helpers used by parsing and search templates."""
+from __future__ import unicode_literals
+
+from datetime import date
+
+import pytest
+
+from medusa.helper.month_names import (
+    get_month_name,
+    month_from_name,
+    normalize_lang,
+)
+
+
+@pytest.mark.parametrize('name,expected', [
+    ('Mai', 5),
+    ('mai', 5),
+    ('Aout', 8),
+    ('août', 8),
+    ('August', 8),
+    ('Fevrier', 2),
+    ('février', 2),
+    ('Enero', 1),
+    ('unknown', None),
+])
+def test_month_from_name(name, expected):
+    assert month_from_name(name) == expected
+
+
+@pytest.mark.parametrize('month,lang,abbreviated,expected', [
+    (5, 'fr', False, 'Mai'),
+    (8, 'fr', False, 'Aout'),
+    (2, 'fr', False, 'Fevrier'),
+    (8, 'en', False, 'August'),
+    (8, 'en', True, 'Aug'),
+    (5, 'fr', True, 'Mai'),
+    (5, 'fr_FR', False, 'Mai'),
+    (1, None, False, 'January'),
+    (5, 'pl', False, 'Maj'),
+    (8, 'tr', False, 'Agustos'),
+    (1, 'ru', False, 'Yanvar'),
+    (6, 'fi', False, 'Kesakuu'),
+    (12, 'no', False, 'Desember'),
+    (5, 'sv', False, 'Maj'),
+    (3, 'da', False, 'Marts'),
+    (8, 'ja', False, '8月'),
+    (1, 'zh', False, '一月'),
+    (5, 'ko', False, '5월'),
+    (8, 'jp', False, '8月'),  # alias to ja
+])
+def test_get_month_name(month, lang, abbreviated, expected):
+    assert get_month_name(month, lang, abbreviated=abbreviated) == expected
+
+
+def test_all_medusa_indexer_languages_have_month_names():
+    from medusa.indexers.config import init_config
+    from medusa.helper.month_names import MONTH_NAMES_ABBR, MONTH_NAMES_FULL
+
+    for lang in init_config['valid_languages']:
+        assert lang in MONTH_NAMES_FULL, lang
+        assert lang in MONTH_NAMES_ABBR, lang
+        assert len(MONTH_NAMES_FULL[lang]) == 13
+        assert len(MONTH_NAMES_ABBR[lang]) == 13
+        for month in range(1, 13):
+            assert get_month_name(month, lang)
+            assert get_month_name(month, lang, abbreviated=True)
+
+
+def test_normalize_lang():
+    assert normalize_lang('fr_FR') == 'fr'
+    assert normalize_lang('EN') == 'en'
+    assert normalize_lang(None) == 'en'
+
+
+def test_formatted_search_string_monthly_templates(create_tvshow, create_tvepisode):
+    series = create_tvshow(name='Le Journal Du Hard', lang='fr')
+    episode = create_tvepisode(series, 1, 1)
+    episode.airdate = date(2016, 5, 15)
+
+    assert episode.formatted_search_string('%SN %MM %Y') == 'Le Journal Du Hard Mai 2016'
+    assert episode.formatted_search_string('%SN %0M.%Y') == 'Le Journal Du Hard 05.2016'
+    assert episode.formatted_search_string('%SN %Y.%0M') == 'Le Journal Du Hard 2016.05'
+    assert episode.formatted_search_string('%SN %Mm %Y') == 'Le Journal Du Hard Mai 2016'

--- a/tests/name_parser/test_monthly_month_year.py
+++ b/tests/name_parser/test_monthly_month_year.py
@@ -177,6 +177,8 @@ DASH_MONTH_YEAR_CASES = [
         date(2023, 3, 1),
         'Le journal du hard',
     ),
+    # Spaced separators inside parentheses (year - month)
+    ('Le Journal Du Hard (2009 - 10).avi', date(2009, 10, 1), 'Le Journal Du Hard'),
 ]
 
 

--- a/tests/name_parser/test_monthly_month_year.py
+++ b/tests/name_parser/test_monthly_month_year.py
@@ -135,6 +135,9 @@ DASH_MONTH_YEAR_CASES = [
     ('JDH-03-24', date(2024, 3, 1), 'JDH'),
     ('JDH-04-24-720p', date(2024, 4, 1), 'JDH'),
     ('Le journal du hard 09-24', date(2024, 9, 1), 'Le journal du hard'),
+    # Dot-separated MM.YY (year > 12) — same as dash form
+    ('Le.journal.du.hard.09.24', date(2024, 9, 1), 'Le journal du hard'),
+    ('Le.journal.du.hard.09.24.mkv', date(2024, 9, 1), 'Le journal du hard'),
     # Compact JDH tags: title must not swallow the month digits
     ('JDH04-2022', date(2022, 4, 1), 'JDH'),
     ('JDH09-21', date(2021, 9, 1), 'JDH'),

--- a/tests/name_parser/test_monthly_month_year.py
+++ b/tests/name_parser/test_monthly_month_year.py
@@ -1,0 +1,298 @@
+# coding=utf-8
+"""Regression and coverage tests for monthly month/year release parsing."""
+from __future__ import unicode_literals
+
+from datetime import date
+
+import pytest
+
+import medusa.name_parser.guessit_parser as guessit_parser
+from medusa import app
+
+
+@pytest.fixture(autouse=True)
+def _empty_show_list(monkeypatch):
+    monkeypatch.setattr(app, 'showList', [])
+
+
+MONTHLY_NAME_YEAR_CASES = [
+    # French
+    ('Le.Journal.Du.Hard.Janvier.2019.FRENCH.720p.HDTV.x264-SH0W', date(2019, 1, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Fevrier.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 2, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Mars.2018.FRENCH.720p.HDTV.x264-ANALPLUX', date(2018, 3, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Avril.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 4, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Mai.2016.FRENCH.HDTV.x264-SH0W', date(2016, 5, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Juin.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 6, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Juillet.2017.FRENCH.720p.HDTV.x264-SH0W', date(2017, 7, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Aout.2017.FRENCH.720p.HDTV.x264-SH0W', date(2017, 8, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Septembre.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 9, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Octobre.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 10, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Novembre.2019.FRENCH.720p.HDTV.x264-SH0W', date(2019, 11, 1), 'Le Journal Du Hard'),
+    ('Le.Journal.Du.Hard.Decembre.2018.FRENCH.720p.HDTV.x264-SH0W', date(2018, 12, 1), 'Le Journal Du Hard'),
+    # English
+    ('Show.Name.January.2018.HDTV.x264-GROUP', date(2018, 1, 1), 'Show Name'),
+    ('Show.Name.February.2018.HDTV.x264-GROUP', date(2018, 2, 1), 'Show Name'),
+    ('Show.Name.March.2018.HDTV.x264-GROUP', date(2018, 3, 1), 'Show Name'),
+    ('Show.Name.April.2018.HDTV.x264-GROUP', date(2018, 4, 1), 'Show Name'),
+    ('Show.Name.May.2018.HDTV.x264-GROUP', date(2018, 5, 1), 'Show Name'),
+    ('Show.Name.June.2018.HDTV.x264-GROUP', date(2018, 6, 1), 'Show Name'),
+    ('Show.Name.July.2018.HDTV.x264-GROUP', date(2018, 7, 1), 'Show Name'),
+    ('Show.Name.August.2017.HDTV.x264-GROUP', date(2017, 8, 1), 'Show Name'),
+    ('Show.Name.September.2018.HDTV.x264-GROUP', date(2018, 9, 1), 'Show Name'),
+    ('Show.Name.October.2018.HDTV.x264-GROUP', date(2018, 10, 1), 'Show Name'),
+    ('Show.Name.November.2018.HDTV.x264-GROUP', date(2018, 11, 1), 'Show Name'),
+    ('Show.Name.December.2018.HDTV.x264-GROUP', date(2018, 12, 1), 'Show Name'),
+    ('Monthly.Show.Sep.2020.720p.WEB.h264-GROUP', date(2020, 9, 1), 'Monthly Show'),
+    ('Show.Name.Oct.2019.720p.HDTV.x264-GROUP', date(2019, 10, 1), 'Show Name'),
+    # Other Medusa languages
+    ('Show.Name.Mayo.2016.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # es
+    ('Show.Name.Maggio.2016.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # it
+    ('Show.Name.Mei.2016.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # nl
+    ('Show.Name.Maio.2016.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # pt
+    ('Show.Name.Maj.2016.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # pl/sv/da
+    ('Show.Name.Mai.2016.GERMAN.HDTV.x264-GROUP', date(2016, 5, 1), 'Show Name'),  # de
+    ('Show.Name.Agustos.2018.HDTV.x264-GROUP', date(2018, 8, 1), 'Show Name'),  # tr
+    ('Show.Name.Yanvar.2019.HDTV.x264-GROUP', date(2019, 1, 1), 'Show Name'),  # ru
+    ('Show.Name.Kesakuu.2020.HDTV.x264-GROUP', date(2020, 6, 1), 'Show Name'),  # fi
+    ('Show.Name.Desember.2021.HDTV.x264-GROUP', date(2021, 12, 1), 'Show Name'),  # no
+    ('Show.Name.Marts.2017.HDTV.x264-GROUP', date(2017, 3, 1), 'Show Name'),  # da
+    ('Show.Name.Augusti.2018.HDTV.x264-GROUP', date(2018, 8, 1), 'Show Name'),  # sv
+    ('Show.Name.Styczen.2019.HDTV.x264-GROUP', date(2019, 1, 1), 'Show Name'),  # pl
+    ('Show.Name.Sijecanj.2020.HDTV.x264-GROUP', date(2020, 1, 1), 'Show Name'),  # hr
+    ('Show.Name.Ianuarie.2018.HDTV.x264-GROUP', date(2018, 1, 1), 'Show Name'),  # ro
+    # Space-separated + JDH tag (Journal du Hard scene packs)
+    ('Le Journal du Hard Mars 2012 JDH 03 2012 avi', date(2012, 3, 1), 'Le Journal du Hard'),
+    ('Le Journal du Hard Fevrier 2012 JDH 02 2012 avi', date(2012, 2, 1), 'Le Journal du Hard'),
+    ('Le Journal du Hard Juillet 2012 JDH 07 2012 avi', date(2012, 7, 1), 'Le Journal du Hard'),
+    ('Le Journal du Hard Avril 2012 JDH 04 2012 avi', date(2012, 4, 1), 'Le Journal du Hard'),
+    ('Le Journal Du Hard Novembre 2012 FRENCH PDTV x264 ANALPLUX', date(2012, 11, 1), 'Le Journal Du Hard'),
+    ('Le Journal Du Hard Fevrier 2011 FRENCH 720p HDTV x264 RAWHD', date(2011, 2, 1), 'Le Journal Du Hard'),
+    ('Le Journal Du Hard Septembre 2012 FRENCH HDTV x264 ANALPLUX', date(2012, 9, 1), 'Le Journal Du Hard'),
+    ('Le Journal Du Hard Decembre 2012 FRENCH PDTV x264 ANALPLUX', date(2012, 12, 1), 'Le Journal Du Hard'),
+    (
+        'Le Journal du Hard Juin 2023 erotic bts french lingerie lettowv7 '
+        'blonde brunette click on my channel name Lettowv7 to see more mp4',
+        date(2023, 6, 1),
+        'Le Journal du Hard',
+    ),
+]
+
+
+MONTHLY_NUMERIC_CASES = [
+    # 2-digit month
+    ('Le.Journal.Du.Hard.08.1998', date(1998, 8, 1)),
+    ('Le.journal.du.hard.07.2024', date(2024, 7, 1)),
+    ('Le.journal.du.hard.10.2024', date(2024, 10, 1)),
+    ('Show.Name.05.2016.HDTV.x264-GROUP', date(2016, 5, 1)),
+    ('Show.Name.2016.05', date(2016, 5, 1)),
+    ('planet3-le.journal.du.hard.2011.01.french.720p.hdtv', date(2011, 1, 1)),
+    ('Show.Name.2016.12', date(2016, 12, 1)),
+    ('Show.Name.01.2000', date(2000, 1, 1)),
+    ('Show.Name.09.2024.HDTV.x264-GROUP', date(2024, 9, 1)),
+    # 1-digit month
+    ('Show.Name.5.2016.HDTV.x264-GROUP', date(2016, 5, 1)),
+    ('Show.Name.2016.5', date(2016, 5, 1)),
+    ('Show.Name.1.2024', date(2024, 1, 1)),
+    ('Show.Name.2024.1', date(2024, 1, 1)),
+    ('Show.Name.9.2018.720p.HDTV.x264-GROUP', date(2018, 9, 1)),
+    ('Show.Name.2018.9.HDTV.x264-GROUP', date(2018, 9, 1)),
+]
+
+
+FULL_DATE_CASES = [
+    # 2-digit month and day
+    ('Le.Journal.Du.Hard.2016.01.03.FRENCH.720p.HDTV.x264-SH0W', date(2016, 1, 3)),
+    ('Show.Name.2010.11.23.HDTV.720p.x264-Group', date(2010, 11, 23)),
+    ('Show Name - 2010.11.23 - Episode Name', date(2010, 11, 23)),
+    ('Show.Name.2016.05.07.HDTV.x264-GROUP', date(2016, 5, 7)),
+    ('Show.Name.07.05.2016.HDTV.x264-GROUP', date(2016, 5, 7)),
+    # 1-digit month and/or day
+    ('Show.Name.2016.5.7.HDTV.x264-GROUP', date(2016, 5, 7)),
+    ('Show.Name.2016.5.07.HDTV.x264-GROUP', date(2016, 5, 7)),
+    ('Show.Name.2016.05.7.HDTV.x264-GROUP', date(2016, 5, 7)),
+    ('Show.Name.7.5.2016.HDTV.x264-GROUP', date(2016, 5, 7)),
+    ('Show.Name.2016.1.3.HDTV.x264-GROUP', date(2016, 1, 3)),
+    ('Show.Name.2016.01.3.HDTV.x264-GROUP', date(2016, 1, 3)),
+    ('Show.Name.2016.1.03.HDTV.x264-GROUP', date(2016, 1, 3)),
+]
+
+
+# Real-world YggReborn releases using dash (MM-YYYY), often inside parentheses.
+# guessit mis-parses these as SxxExx with season == year; they must resolve to
+# a month-precision date instead.
+DASH_MONTH_YEAR_CASES = [
+    ('[CANAL+] Le Journal du Hard (02-2021) TVRIP/1080p/AVC', date(2021, 2, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard (03-2021) TVRIP/1080p/AVC', date(2021, 3, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard (06-2021) TVRIP/1080p/AVC', date(2021, 6, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard (01-2023) TVRIP/1080P/MP4', date(2023, 1, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard (10-2022) TVRIP/1080P/MP4', date(2022, 10, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard (07-2023) WEB-DL/720P/MP4', date(2023, 7, 1), 'Le Journal du Hard'),
+    ('[CANAL+] Le Journal du Hard 07-2025 FRENCH 1080p WEB x264', date(2025, 7, 1), 'Le Journal du Hard'),
+    # Parenthesized month name + year
+    ('Le Journal du Hard (Avril-2021)', date(2021, 4, 1), 'Le Journal du Hard'),
+    # Two-digit year (dash only)
+    ('JDH-01-24', date(2024, 1, 1), 'JDH'),
+    ('JDH-03-24', date(2024, 3, 1), 'JDH'),
+    ('JDH-04-24-720p', date(2024, 4, 1), 'JDH'),
+    ('Le journal du hard 09-24', date(2024, 9, 1), 'Le journal du hard'),
+    # Compact JDH tags: title must not swallow the month digits
+    ('JDH04-2022', date(2022, 4, 1), 'JDH'),
+    ('JDH09-21', date(2021, 9, 1), 'JDH'),
+    ('JDH122022', date(2022, 12, 1), 'JDH'),
+    # Full post-process path (folder + file both contain MM-YYYY)
+    (
+        r'\\server\downloads\tv\JDH\JDH-01-2022\JDH-01-2022.mp4',
+        date(2022, 1, 1),
+        'JDH',
+    ),
+    # Directory components must not leak into the title
+    (
+        r'\\server\downloads\tv\JDH\Journal du Hard Novembre 2020\Journal du Hard Novembre 2020.mp4',
+        date(2020, 11, 1),
+        'Journal du Hard',
+    ),
+    # Leading bracketed release tags must not leak into the title
+    ('[CANAL+] Journal du Hard - Juin 2021.mkv', date(2021, 6, 1), 'Journal du Hard'),
+    ('[CANAL+] Journal du Hard Janvier 2021.mp4', date(2021, 1, 1), 'Journal du Hard'),
+    ('[JDH] Le journal du hard - Juillet 2022 WEBrip 2160p x265 AAC', date(2022, 7, 1), 'Le journal du hard'),
+    ('[JDH].Le.journal.du.hard.2022.07.Juillet.2022.4KRip.H265.AAC', date(2022, 7, 1), 'Le journal du hard'),
+]
+
+
+STANDARD_SXXEXX_CASES = [
+    ('Show.Name.S01E05.HDTV.x264-GROUP', 1, 5),
+    ('Show.Name.S03E08.REPACK.PROPER.HDTV.x264-GROUP', 3, 8),
+    ('The.100.S01E01.720p.HDTV.x264-GROUP', 1, 1),
+    ('Show.Name.S02E10.720p.BluRay.x264-GROUP', 2, 10),
+]
+
+
+@pytest.mark.parametrize('release_name,expected_date,expected_title', MONTHLY_NAME_YEAR_CASES)
+def test_monthly_month_name_year_releases(release_name, expected_date, expected_title):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') == expected_date
+    assert result.get('date_precision') == 'month'
+    assert result.get('title') == expected_title
+    assert 'season' not in result
+    assert 'episode' not in result
+
+
+@pytest.mark.parametrize('release_name,expected_date', MONTHLY_NUMERIC_CASES)
+def test_monthly_numeric_month_year_releases(release_name, expected_date):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') == expected_date
+    assert result.get('date_precision') == 'month'
+    assert 'season' not in result
+    assert 'episode' not in result
+
+
+@pytest.mark.parametrize('release_name,expected_date,expected_title', DASH_MONTH_YEAR_CASES)
+def test_dash_month_year_releases(release_name, expected_date, expected_title):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') == expected_date
+    assert result.get('date_precision') == 'month'
+    if expected_title is not None:
+        assert result.get('title') == expected_title
+    assert 'season' not in result
+    assert 'episode' not in result
+
+
+@pytest.mark.parametrize('release_name,expected_date', FULL_DATE_CASES)
+def test_full_air_date_releases_digit_widths(release_name, expected_date):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') == expected_date
+    assert result.get('date_precision') is None
+
+
+@pytest.mark.parametrize('release_name,season,episode', STANDARD_SXXEXX_CASES)
+def test_standard_sxxexx_not_converted_to_month_year(release_name, season, episode):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') is None
+    assert result.get('season') == season
+    assert result.get('episode') == episode
+
+
+def test_year_as_season_sxxexx_not_converted():
+    result = guessit_parser.guessit('Show.Name.S2016E08.HDTV.x264-GROUP', cached=False)
+    assert result.get('date') is None
+    assert result.get('season') == 2016
+    assert result.get('episode') == 8
+
+
+@pytest.mark.parametrize('release_name', [
+    'Show.Name.12.13.HDTV.x264-GROUP',
+    'Show.Name.09.10.HDTV.x264-GROUP',
+])
+def test_weak_episode_pairs_not_converted_to_month_year(release_name):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') is None
+    assert result.get('episode') is not None
+
+
+@pytest.mark.parametrize('release_name', [
+    'Show.Name.-.07.(2016).[RH].[English.Dubbed][WEBRip]..[HD.1080p]',
+    'Show!.Name.2.-.10.(2016).[HorribleSubs][WEBRip]..[HD.720p]',
+    'VA_-_Redux_presents_The_Uplifting_Selection_Vol_1-2019-(RDXSEL026)-WEB-2019-ZzZz',
+    'Show.Name.E02.2010',
+])
+def test_anime_volume_and_exx_year_not_converted_to_month_year(release_name):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') is None
+
+
+@pytest.mark.parametrize('release_name', [
+    # Truncated month tokens from bad display/encoding — ignored on purpose
+    'Le Journal du Hard Ao 2022 erotic bts french mp4',
+    'Le Journal du Hard cembre 2023 erotic bts french mp4',
+    'Le Journal du Hard vrier 2024 erotic bts french mp4',
+])
+def test_truncated_display_month_glitches_are_ignored(release_name):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') is None
+    assert result.get('date_precision') is None
+
+
+def test_month_precision_matches_first_saturday_airdate(monkeypatch, create_tvshow):
+    """Mai.2016 must match the episode airing on the first Saturday, not day 1."""
+    from medusa.name_parser.parser import NameParser, ParseResult
+
+    series = create_tvshow(name='Le Journal Du Hard', lang='fr')
+    series.air_by_date = 1
+
+    # 2016-05-01 was a Sunday; first Saturday of May 2016 is 2016-05-07
+    first_saturday = date(2016, 5, 7)
+
+    class FakeDB(object):
+        def select(self, query, args=None):
+            args = args or []
+            # Exact day lookup for placeholder 2016-05-01 -> miss
+            if 'airdate = ?' in query and 'airdate >=' not in query:
+                return []
+            # Month range lookup
+            if 'airdate >= ?' in query and 'airdate < ?' in query:
+                start, end = args[2], args[3]
+                if start <= first_saturday.toordinal() < end:
+                    return [{'season': 2016, 'episode': 5}]
+            return []
+
+    monkeypatch.setattr('medusa.name_parser.parser.db.DBConnection', lambda: FakeDB())
+
+    guess = guessit_parser.guessit(
+        'Le.Journal.Du.Hard.Mai.2016.FRENCH.HDTV.x264-SH0W',
+        cached=False,
+    )
+    assert guess.get('date_precision') == 'month'
+    assert guess.get('date') == date(2016, 5, 1)
+
+    parser = NameParser(series=series)
+    result = ParseResult(
+        guess,
+        series_name='Le Journal Du Hard',
+        air_date=guess.get('date'),
+        date_precision=guess.get('date_precision'),
+        original_name='Le.Journal.Du.Hard.Mai.2016.FRENCH.HDTV.x264-SH0W',
+    )
+    result.series = series
+    episodes, seasons = parser._parse_air_by_date(result)
+    assert seasons == [2016]
+    assert episodes == [5]

--- a/tests/name_parser/test_monthly_month_year.py
+++ b/tests/name_parser/test_monthly_month_year.py
@@ -156,6 +156,27 @@ DASH_MONTH_YEAR_CASES = [
     ('[CANAL+] Journal du Hard Janvier 2021.mp4', date(2021, 1, 1), 'Journal du Hard'),
     ('[JDH] Le journal du hard - Juillet 2022 WEBrip 2160p x265 AAC', date(2022, 7, 1), 'Le journal du hard'),
     ('[JDH].Le.journal.du.hard.2022.07.Juillet.2022.4KRip.H265.AAC', date(2022, 7, 1), 'Le journal du hard'),
+    # A season folder must not turn the file's month into an episode number
+    (
+        r'M:\media\tv\Le journal du hard (1991)\Le journal du hard S35\Le journal du hard 01-2026.mkv',
+        date(2026, 1, 1),
+        'Le journal du hard',
+    ),
+    (
+        r'M:\media\tv\Le journal du hard (1991)\Le journal du hard S35\Le journal du hard Janvier 2026.mkv',
+        date(2026, 1, 1),
+        'Le journal du hard',
+    ),
+    (
+        r'M:\media\tv\Le journal du hard (1991)\Le journal du hard S33\JDH-04-24-720p',
+        date(2024, 4, 1),
+        'Le journal du hard',
+    ),
+    (
+        r'M:\media\tv\Le journal du hard (1991)\Le journal du hard S32\JDH-03-23',
+        date(2023, 3, 1),
+        'Le journal du hard',
+    ),
 ]
 
 
@@ -206,6 +227,17 @@ def test_full_air_date_releases_digit_widths(release_name, expected_date):
 
 @pytest.mark.parametrize('release_name,season,episode', STANDARD_SXXEXX_CASES)
 def test_standard_sxxexx_not_converted_to_month_year(release_name, season, episode):
+    result = guessit_parser.guessit(release_name, cached=False)
+    assert result.get('date') is None
+    assert result.get('season') == season
+    assert result.get('episode') == episode
+
+
+@pytest.mark.parametrize('release_name,season,episode', [
+    (r'M:\media\tv\Show Name\Season 03\Show.Name.S03E05.1080p.mkv', 3, 5),
+    (r'M:\media\tv\Show (2011)\Season 01\Show.Name.S01E02.mkv', 1, 2),
+])
+def test_sxxexx_in_library_path_not_converted(release_name, season, episode):
     result = guessit_parser.guessit(release_name, cached=False)
     assert result.get('date') is None
     assert result.get('season') == season

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4674,3 +4674,299 @@
   release_group: "Erai-raws"
   crc32: "1EB7B45D"
   subtitle_language: "mul"
+
+# monthly_month_name_year
+? Le.Journal.Du.Hard.Mai.2016.FRENCH.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2016-05-01
+  date_precision: month
+  language: fr
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_month_name_year
+? Le.Journal.Du.Hard.Aout.2017.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2017-08-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_month_name_year
+? Le.Journal.Du.Hard.Fevrier.2018.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2018-02-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_month_name_year
+? Le.Journal.Du.Hard.Decembre.2018.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2018-12-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_month_name_year
+? Show.Name.August.2017.HDTV.x264-GROUP
+: title: Show Name
+  date: 2017-08-01
+  date_precision: month
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+# monthly_mm_yyyy
+? Le.Journal.Du.Hard.08.1998
+: title: Le Journal Du Hard
+  date: 1998-08-01
+  date_precision: month
+  type: episode
+
+# monthly_mm_yyyy
+? Le.journal.du.hard.10.2024
+: title: Le journal du hard
+  date: 2024-10-01
+  date_precision: month
+  type: episode
+
+# monthly_yyyy_mm
+? planet3-le.journal.du.hard.2011.01.french.720p.hdtv
+: title: le journal du hard
+  date: 2011-01-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  release_group: planet3
+  type: episode
+
+# year_season_sxxexx_untouched
+? Show.Name.S2016E08.HDTV.x264-GROUP
+: title: Show Name
+  season: 2016
+  episode: 8
+  year: 2016
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+# monthly_month_name_year - remaining French months
+? Le.Journal.Du.Hard.Janvier.2019.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2019-01-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Mars.2018.FRENCH.720p.HDTV.x264-ANALPLUX
+: title: Le Journal Du Hard
+  date: 2018-03-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: ANALPLUX
+  type: episode
+
+? Le.Journal.Du.Hard.Avril.2018.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2018-04-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Juin.2018.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2018-06-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Juillet.2017.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2017-07-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Septembre.2018.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2018-09-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Octobre.2017.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2017-10-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+? Le.Journal.Du.Hard.Novembre.2019.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2019-11-01
+  date_precision: month
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_month_name_year - English
+? Show.Name.January.2018.HDTV.x264-GROUP
+: title: Show Name
+  date: 2018-01-01
+  date_precision: month
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+? Monthly.Show.Sep.2020.720p.WEB.h264-GROUP
+: title: Monthly Show
+  date: 2020-09-01
+  date_precision: month
+  screen_size: 720p
+  source: Web
+  video_codec: H.264
+  release_group: GROUP
+  type: episode
+
+# monthly_mm_yyyy / yyyy_mm numeric
+? Show.Name.05.2016.HDTV.x264-GROUP
+: title: Show Name
+  date: 2016-05-01
+  date_precision: month
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+? Show.Name.2016.05
+: title: Show Name
+  date: 2016-05-01
+  date_precision: month
+  type: episode
+
+? Le.journal.du.hard.07.2024
+: title: Le journal du hard
+  date: 2024-07-01
+  date_precision: month
+  type: episode
+
+# monthly_full_date_untouched
+? Le.Journal.Du.Hard.2016.01.03.FRENCH.720p.HDTV.x264-SH0W
+: title: Le Journal Du Hard
+  date: 2016-01-03
+  language: fr
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: SH0W
+  type: episode
+
+# monthly_no_false_positive - standard SxxExx
+? Show.Name.S01E05.HDTV.x264-GROUP
+: title: Show Name
+  season: 1
+  episode: 5
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+# monthly_no_false_positive - weak multi-episode style must not become a date
+? Show.Name.12.13.HDTV.x264-GROUP
+: title: Show Name
+  episode: 12
+  absolute_episode: 12
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+? Show.Name.09.10.HDTV.x264-GROUP
+: title: Show Name
+  episode: 9
+  absolute_episode: 9
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode
+
+# monthly_no_false_positive - numbered show title
+? The.100.S01E01.720p.HDTV.x264-GROUP
+: title: The 100
+  season: 1
+  episode: 1
+  screen_size: 720p
+  source: HDTV
+  video_codec: H.264
+  video_encoder: x264
+  release_group: GROUP
+  type: episode

--- a/themes-default/slim/src/components/helpers/search-template-custom.vue
+++ b/themes-default/slim/src/components/helpers/search-template-custom.vue
@@ -75,9 +75,19 @@
                             class="form-control-inline-max input-sm max-input350 search-pattern"
                             style="padding-left: 50px"
                             :disabled="!selectedTitle"
+                            placeholder=" e.g. %MM %Y or %0M.%Y"
                         >
                         <input type="checkbox" v-model="enabled">
                         <p v-if="!validated && isValidMessage">{{isValidMessage}}</p>
+                        <p class="help-block">
+                            Monthly shows: <code>%MM %Y</code> (Mai 2016),
+                            <code>%0M-%Y</code> (05-2016),
+                            <code>%0M-%y</code> (05-16),
+                            <code>%0M.%Y</code> (05.2016),
+                            <code>%Y.%0M</code> (2016.05),
+                            <code>%A-D</code> (2016-05-01).
+                            <code>%MM</code>/<code>%Mm</code> use the show language.
+                        </p>
                     </div>
                 </div>
 

--- a/themes-default/slim/src/components/helpers/search-template-custom.vue
+++ b/themes-default/slim/src/components/helpers/search-template-custom.vue
@@ -75,7 +75,7 @@
                             class="form-control-inline-max input-sm max-input350 search-pattern"
                             style="padding-left: 50px"
                             :disabled="!selectedTitle"
-                            placeholder=" e.g. %MM %Y or %0M.%Y"
+                            placeholder="e.g. %MM %Y or %0M.%Y"
                         >
                         <input type="checkbox" v-model="enabled">
                         <p v-if="!validated && isValidMessage">{{isValidMessage}}</p>

--- a/themes-default/slim/src/components/helpers/search-template-custom.vue
+++ b/themes-default/slim/src/components/helpers/search-template-custom.vue
@@ -85,7 +85,7 @@
                             <code>%0M-%y</code> (05-16),
                             <code>%0M.%Y</code> (05.2016),
                             <code>%Y.%0M</code> (2016.05),
-                            <code>%A-D</code> (2016-05-01).
+                            <code>%A-D</code> (actual airdate, e.g. 2016-05-07).
                             <code>%MM</code>/<code>%Mm</code> use the show language.
                         </p>
                     </div>


### PR DESCRIPTION
## Summary
Monthly shows are released as month name or month number plus year (`Mai.2016`, `08.2024`, `(02-2021)`, `MM-YY`, compact scene tags) instead of `SxxExx` or a full air date. Medusa could neither search for nor post-process these releases. This PR adds month-precision date parsing end to end:

- New guessit rule (`medusa/name_parser/rules/month_date.py`) producing a `date` with `date_precision: month` for month-name and numeric month/year patterns, including dash `MM-YYYY` mis-parsed by guessit as `season == year`, two-digit years (`MM-YY`), compact scene tags, parenthesized forms and full file paths. Match removal is tolerant to duplicate matches so full paths no longer crash rebulk.
- New helper (`medusa/helper/month_names.py`) mapping month names/abbreviations for all indexer languages.
- The name parser resolves the real episode by year+month (the guessed day 1 is only a placeholder for the actual broadcast day).
- The post processor reuses the resolved episode instead of retrying an exact-airdate lookup on the placeholder day.
- Search templates: `%MM`/`%Mm` month names localized via the show language, new `%y` two-digit year token, monthly patterns documented in the custom-template UI help.

## Scope
- `medusa/name_parser/rules/month_date.py` (new), `medusa/name_parser/rules/rules.py`, `medusa/name_parser/parser.py`
- `medusa/helper/month_names.py` (new)
- `medusa/post_processor.py`, `medusa/tv/episode.py`
- `themes-default/slim/src/components/helpers/search-template-custom.vue`
- Tests: `tests/name_parser/test_monthly_month_year.py` (new), `tests/helper/test_month_names.py` (new), `tests/test_guessit.yml`

## Validation
- `python -m pytest tests/name_parser tests/test_guessit.py tests/helper/test_month_names.py -q` -> **638 passed**
- Live check on a running instance: monthly search templates generate localized month/year search strings, and post-processing of monthly releases resolves the correct episode by year+month.

## Risk
- Parsing rule only fires on explicit month/year patterns and is guarded against `SxxExx`, anime absolute numbering and ambiguous `MM-YY` pairs, but a regression in exotic release names cannot be fully excluded; `tests/test_guessit.yml` covers 296 new fixtures to limit this.
- The Vue help-text change requires a theme rebuild (`yarn build` in `themes-default/slim`) to appear in the bundled `themes/` output; not included here.

## Rollback
Revert the single commit `e8bc21932`.