### PR TITLE
fix: adapt Medusa parsing rules to GuessIt 4

### DIFF
--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -7,8 +7,8 @@ import logging
 import threading
 
 from medusa import app, db
-from medusa.helpers import full_sanitize_scene_name
 from medusa.logger.adapters.style import BraceAdapter
+from medusa.name_parser.series_name import normalize_series_name_for_comparison
 from medusa.scene_exceptions import (
     exceptions_cache,
     refresh_exceptions_cache,
@@ -35,7 +35,7 @@ def addNameToCache(name, indexer_id=1, series_id=0):
     cache_db_con = db.DBConnection('cache.db')
 
     # standardize the name we're using to account for small differences in providers
-    name = full_sanitize_scene_name(name)
+    name = normalize_series_name_for_comparison(name)
     if name not in name_cache:
         name_cache[name] = (indexer_id, series_id)
         cache_db_con.action('INSERT OR REPLACE INTO scene_names (indexer_id, name, indexer) VALUES (?, ?, ?)', [series_id, name, indexer_id])
@@ -48,7 +48,7 @@ def retrieveNameFromCache(name):
     :param name: The show name to look up.
     :return: Return a tuple with two items. First: indexer_id, Second: series_id.
     """
-    name = full_sanitize_scene_name(name)
+    name = normalize_series_name_for_comparison(name)
     if name in name_cache:
         return name_cache[name]
     return None, None
@@ -97,12 +97,12 @@ def build_name_cache(series_obj=None):
         series_identifier = (cache_series_obj.indexer, cache_series_obj.series_id)
         scene_exceptions = exceptions_cache[series_identifier].copy()
         names = {
-            full_sanitize_scene_name(exception.title): series_identifier
+            normalize_series_name_for_comparison(exception.title): series_identifier
             for season_exceptions in itervalues(scene_exceptions)
             for exception in season_exceptions
         }
         # Add original name to name cache
-        series_name = full_sanitize_scene_name(cache_series_obj.name)
+        series_name = normalize_series_name_for_comparison(cache_series_obj.name)
         names[series_name] = series_identifier
 
         # Add scene exceptions to name cache

--- a/medusa/name_parser/rules/__init__.py
+++ b/medusa/name_parser/rules/__init__.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 from guessit.api import default_api
 
+from medusa.name_parser.rules.expected_patch import apply_expected_value_patch
 from medusa.name_parser.rules.properties import (
     blacklist,
     container,
@@ -15,8 +16,10 @@ from medusa.name_parser.rules.properties import (
 )
 from medusa.name_parser.rules.rules import rules
 
+# Must run before configure() rebuilds title/release_group expected matchers.
+apply_expected_value_patch()
 
-default_api.configure({})
+default_api.configure({}, force=True)
 default_api.rebulk.rebulk(blacklist())
 default_api.rebulk.rebulk(source())
 default_api.rebulk.rebulk(screen_size())

--- a/medusa/name_parser/rules/expected_patch.py
+++ b/medusa/name_parser/rules/expected_patch.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""Medusa patch for GuessIt expected_title / expected_group values."""
+from __future__ import unicode_literals
+
+from rebulk import Rebulk
+from rebulk.remodule import re
+from rebulk.utils import find_all
+
+from guessit.rules.common import dash, seps
+
+
+def build_expected_function(context_key):
+    """Match loosely but keep the original expected string as Match.value.
+
+    GuessIt 4.1.0 otherwise uses the separator-normalized substring as the value
+    (``11.22.63`` -> ``11 22 63``). Medusa needs GuessIt 3.x semantics: punctuation
+    from the expected search string is preserved (Rebulk skips formatters when
+    value is set).
+
+    Applied from :mod:`medusa.name_parser.rules` before ``default_api.configure``
+    so a future vendoring of ``lib/guessit`` does not silently drop the fix.
+    Consider proposing this behavior upstream.
+    """
+
+    def expected(input_string, context):
+        ret = []
+        for search in context.get(context_key) or ():
+            if search.startswith('re:'):
+                search = search[3:]
+                search = search.replace(' ', '-')
+                matches = (
+                    Rebulk()
+                    .regex(search, abbreviations=[dash], flags=re.IGNORECASE)
+                    .matches(input_string, context)
+                )
+                for match in matches:
+                    ret.append(match.span)
+            else:
+                value = search
+                normalized_input = input_string
+                normalized_search = search
+                for sep in seps:
+                    normalized_input = normalized_input.replace(sep, ' ')
+                    normalized_search = normalized_search.replace(sep, ' ')
+                for start in find_all(normalized_input, normalized_search, ignore_case=True):
+                    ret.append({
+                        'start': start,
+                        'end': start + len(normalized_search),
+                        'value': value,
+                    })
+        return ret
+
+    return expected
+
+
+def apply_expected_value_patch():
+    """Patch GuessIt modules that bind ``build_expected_function`` at import time."""
+    import guessit.rules.common.expected as expected_mod
+    import guessit.rules.properties.release_group as release_group_mod
+    import guessit.rules.properties.title as title_mod
+
+    expected_mod.build_expected_function = build_expected_function
+    title_mod.build_expected_function = build_expected_function
+    release_group_mod.build_expected_function = build_expected_function

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1989,10 +1989,12 @@ class FixEpisodeTitleAsMultiSeason(Rule):
             if not previous:
                 return
 
-            episode_title = episode_titles[0]
-            if not str(episode_title.value)[0].isdigit():
+            # Use the episode_title immediately before the weak season, not titles[0].
+            episode_title = previous[0]
+            title_text = str(episode_title.value or '')
+            if title_text and not title_text[0].isdigit():
                 fixed_episode_title = copy.copy(episode_title)
-                fixed_episode_title.value = episode_title.value + ' ' + str(season.value)
+                fixed_episode_title.value = title_text + ' ' + str(season.value)
                 to_remove.append(episode_title)
                 to_append.append(fixed_episode_title)
             to_remove.append(season)

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1406,24 +1406,44 @@ class RestoreSeasonFromXPattern(Rule):
         to_remove = []
         to_append = []
         for episode in matches.named('episode'):
-            initiator_value = str(getattr(episode.initiator, 'value', '') or '')
-            initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
-            matched = (
-                self.season_x_episode.match(initiator_value)
-                or self.season_x_episode.match(initiator_raw)
-            )
+            initiator = episode.initiator
+            initiator_raw = str(getattr(initiator, 'raw', '') or '')
+            initiator_value = str(getattr(initiator, 'value', '') or '')
+            # Prefer raw so group offsets map onto absolute input coordinates.
+            matched = self.season_x_episode.match(initiator_raw)
             if not matched:
+                matched = self.season_x_episode.match(initiator_value)
+            if not matched:
+                continue
+
+            base_start = initiator.start
+            season_start = base_start + matched.start('season')
+            season_end = base_start + matched.end('season')
+            if season_start >= season_end:
                 continue
 
             season = copy.copy(episode)
             season.name = 'season'
             season.value = int(matched.group('season'))
+            season.start = season_start
+            season.end = season_end
             to_append.append(season)
 
             expected_episode = int(matched.group('episode'))
-            if episode.value != expected_episode:
+            episode_start = base_start + matched.start('episode')
+            episode_end = base_start + matched.end('episode')
+            need_value_fix = episode.value != expected_episode
+            need_span_fix = (
+                episode_start < episode_end
+                and (episode.start != episode_start or episode.end != episode_end)
+            )
+            if need_value_fix or need_span_fix:
                 fixed_episode = copy.copy(episode)
-                fixed_episode.value = expected_episode
+                if need_value_fix:
+                    fixed_episode.value = expected_episode
+                if episode_start < episode_end:
+                    fixed_episode.start = episode_start
+                    fixed_episode.end = episode_end
                 to_remove.append(episode)
                 to_append.append(fixed_episode)
 
@@ -1907,7 +1927,7 @@ class FixEpisodeTitleAsMultiSeason(Rule):
     """
 
     priority = POST_PROCESS
-    consequence = [RemoveMatch]
+    consequence = [RemoveMatch, AppendMatch]
 
     def when(self, matches, context):
         """Evaluate the rule.
@@ -1961,6 +1981,7 @@ class FixEpisodeTitleAsMultiSeason(Rule):
             return
 
         to_remove = []
+        to_append = []
 
         episode_titles = matches.named('episode_title')
         if episode_titles:
@@ -1970,18 +1991,24 @@ class FixEpisodeTitleAsMultiSeason(Rule):
 
             episode_title = episode_titles[0]
             if not str(episode_title.value)[0].isdigit():
-                episode_title.value = episode_title.value + ' ' + str(season.value)
+                fixed_episode_title = copy.copy(episode_title)
+                fixed_episode_title.value = episode_title.value + ' ' + str(season.value)
+                to_remove.append(episode_title)
+                to_append.append(fixed_episode_title)
             to_remove.append(season)
         else:
             previous = matches.previous(season, predicate=lambda match: match.name == 'episode')
             if not previous:
                 return
 
-            episode_title = season
-            episode_title.name = 'episode_title'
-            episode_title.value = str(season.value)
+            new_episode_title = copy.copy(season)
+            new_episode_title.name = 'episode_title'
+            new_episode_title.value = str(season.value)
+            to_remove.append(season)
+            to_append.append(new_episode_title)
 
-        return to_remove
+        if to_remove or to_append:
+            return to_remove, to_append
 
 
 class PartsAsEpisodeNumbers(Rule):

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -729,14 +729,26 @@ class AnimeWithSeasonAbsoluteEpisodeNumbers(Rule):
 
                 title = matches.previous(season, index=-1,
                                          predicate=lambda match: match.name == 'title' and match.end <= filepart.end)
-                episode_title = matches.next(season, index=0,
-                                             predicate=lambda match: (match.name == 'episode_title' and
-                                                                      match.end <= filepart.end and
-                                                                      match.value.isdigit()))
+                # GuessIt 3 often left the absolute number as episode_title; GuessIt 4
+                # may already classify it as episode. Accept either when it is numeric.
+                absolute_candidate = matches.next(
+                    season,
+                    index=0,
+                    predicate=lambda match: (
+                        match.end <= filepart.end
+                        # Keep regular SxxExx pairs intact; only absorb a separate
+                        # numeric token after a title-season marker like ``S2.-.19``.
+                        and match.parent is not season.parent
+                        and (
+                            (match.name == 'episode_title' and str(match.value).isdigit())
+                            or (match.name == 'episode' and isinstance(match.value, int))
+                        )
+                    ),
+                )
 
                 # the previous match before the season is the series name and
-                # the match after season is episode title and episode title is a number
-                if not title or not episode_title:
+                # the match after season is a numeric absolute episode
+                if not title or not absolute_candidate:
                     continue
 
                 to_remove = []
@@ -754,16 +766,28 @@ class AnimeWithSeasonAbsoluteEpisodeNumbers(Rule):
                 to_remove.append(title)
                 to_append.append(new_title)
 
-                # move episode_title to absolute_episode
-                absolute_episode = copy.copy(episode_title)
+                # move absolute candidate to absolute_episode
+                absolute_episode = copy.copy(absolute_candidate)
                 absolute_episode.name = 'absolute_episode'
-                absolute_episode.value = int(episode_title.value)
+                absolute_episode.value = int(absolute_candidate.value)
 
                 # always keep episode (subliminal needs it)
                 episode = copy.copy(absolute_episode)
                 episode.name = 'episode'
 
-                to_remove.append(episode_title)
+                to_remove.append(absolute_candidate)
+                # Drop duplicate episode matches for the same absolute number in this filepart
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'episode'
+                            and match is not absolute_candidate
+                            and match.value == absolute_episode.value
+                        ),
+                    )
+                )
                 to_append.append(absolute_episode)
                 to_append.append(episode)
                 return to_remove, to_append
@@ -853,7 +877,46 @@ class AnimeWithSeasonMultipleEpisodeNumbers(Rule):
 
             title = matches.previous(episodes[0], index=-1,
                                      predicate=lambda match: match.name == 'title' and match.end <= filepart.end)
-            if not title or self.ends_with_digit.search(str(title.value)):
+            if not title:
+                continue
+
+            # GuessIt 4 may already fold the season digit into the title
+            # (e.g. path "High Score Girl 2" + filename "... Girl 2 - 01").
+            # In that case drop the weak episode that duplicates the title suffix.
+            if self.ends_with_digit.search(str(title.value)):
+                title_suffix = str(title.value).rstrip()
+                suffix_digits = re.search(r'(\d+)$', title_suffix)
+                if not suffix_digits:
+                    continue
+                absorbed = int(suffix_digits.group(1))
+                other_episodes = [episode for episode in episodes if episode.value != absorbed]
+                if not other_episodes:
+                    continue
+                # Drop weak episodes that duplicate the season digit already in the title.
+                to_remove.extend(
+                    episode for episode in episodes
+                    if episode.value == absorbed
+                )
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'absolute_episode' and match.value == absorbed
+                        ),
+                    )
+                )
+                # Path titles like "High Score Girl 2" can leave a truncated episode_title.
+                to_remove.extend(
+                    matches.range(
+                        filepart.start,
+                        filepart.end,
+                        predicate=lambda match: (
+                            match.name == 'episode_title'
+                            and str(title.value).startswith(str(match.value))
+                        ),
+                    )
+                )
                 continue
 
             for i, episode in enumerate(episodes):
@@ -868,6 +931,28 @@ class AnimeWithSeasonMultipleEpisodeNumbers(Rule):
 
                 if i == 1 and len(episodes) in (3, 4):
                     to_remove.append(episode)
+
+        # Global cleanup when the retained title already contains the season digit.
+        for title in matches.named('title'):
+            suffix_digits = re.search(r'(\d+)$', str(title.value).rstrip())
+            if not suffix_digits:
+                continue
+            absorbed = int(suffix_digits.group(1))
+            episodes = matches.named('episode')
+            if not episodes:
+                continue
+            if any(episode.value != absorbed for episode in episodes):
+                to_remove.extend(
+                    episode for episode in episodes if episode.value == absorbed
+                )
+                to_remove.extend(
+                    match for match in matches.named('absolute_episode')
+                    if match.value == absorbed
+                )
+                to_remove.extend(
+                    match for match in matches.named('episode_title')
+                    if str(title.value).startswith(str(match.value))
+                )
 
         return to_remove, to_append
 
@@ -987,6 +1072,9 @@ class OnePreGroupAsMultiEpisode(Rule):
     - The last episode should be removed
     - Episode title should be release group
 
+    GuessIt 4 may instead fold the numeric prefix into release_group
+    (e.g. ``1-URANiME``). Strip that prefix and keep absolute numbering.
+
     e.g.: Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated
 
     guessit -t episode "Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated"
@@ -1024,6 +1112,7 @@ class OnePreGroupAsMultiEpisode(Rule):
 
     priority = POST_PROCESS
     consequence = [RemoveMatch, AppendMatch]
+    numeric_group_prefix = re.compile(r'^\W*\d+-')
 
     def when(self, matches, context):
         """Evaluate the rule.
@@ -1038,11 +1127,40 @@ class OnePreGroupAsMultiEpisode(Rule):
         if not titles:
             return
 
+        is_anime = context.get('show_type') == 'anime' or matches.tagged('anime')
+
         episodes = matches.named('episode')
+        release_groups = matches.named('release_group')
+
+        # GuessIt 4 path: single episode + release_group like "1-URANiME"
+        if (
+            episodes
+            and len(episodes) == 1
+            and not matches.named('season')
+            and release_groups
+            and not matches.named('absolute_episode')
+        ):
+            release_group = release_groups[0]
+            raw_group = release_group.raw or release_group.value or ''
+            if self.numeric_group_prefix.match(str(raw_group)) or self.numeric_group_prefix.match(
+                str(release_group.value)
+            ):
+                to_remove = [release_group]
+                to_append = []
+
+                cleaned = copy.copy(release_group)
+                cleaned.value = self.numeric_group_prefix.sub('', str(release_group.value)).strip()
+                if cleaned.value:
+                    to_append.append(cleaned)
+
+                absolute_episode = copy.copy(episodes[0])
+                absolute_episode.name = 'absolute_episode'
+                to_append.append(absolute_episode)
+                return to_remove, to_append
+
         if not episodes or len(episodes) != 2:
             return
 
-        is_anime = context.get('show_type') == 'anime' or matches.tagged('anime')
         if is_anime or matches.named('season'):
             return
 
@@ -1211,6 +1329,7 @@ class AbsoluteEpisodeNumbers(Rule):
     consequence = [RemoveMatch, AppendMatch]
     non_words_re = re.compile(r'\W')
     episode_words = ('e', 'episode', 'ep')
+    season_x_episode = re.compile(r'^\d+x\d+$', flags=re.IGNORECASE)
 
     def when(self, matches, context):
         """Evaluate the rule.
@@ -1227,6 +1346,13 @@ class AbsoluteEpisodeNumbers(Rule):
             to_remove = []
             to_append = []
             for episode in episodes:
+                # GuessIt 4 may keep only the episode child of an ``01x01`` pattern.
+                # That is still seasonal numbering, not an absolute anime episode.
+                initiator_value = str(getattr(episode.initiator, 'value', '') or '')
+                initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
+                if self.season_x_episode.match(initiator_value) or self.season_x_episode.match(initiator_raw):
+                    continue
+
                 # And there's no episode count
                 if matches.named('episode_count'):
                     # Some.Show.1of8..Title.x264.AAC.Group
@@ -1257,6 +1383,417 @@ class AbsoluteEpisodeNumbers(Rule):
                 to_append.append(absolute_episode)
 
             return to_remove, to_append
+
+
+class RestoreSeasonFromXPattern(Rule):
+    """Restore season when GuessIt keeps only the episode half of an ``NNxNN`` pattern.
+
+    e.g.: Rugrats - 01x01 - Title.avi
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    season_x_episode = re.compile(
+        r'^(?P<season>\d+)x(?P<episode>\d+)$',
+        flags=re.IGNORECASE,
+    )
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        to_remove = []
+        to_append = []
+        for episode in matches.named('episode'):
+            initiator_value = str(getattr(episode.initiator, 'value', '') or '')
+            initiator_raw = str(getattr(episode.initiator, 'raw', '') or '')
+            matched = (
+                self.season_x_episode.match(initiator_value)
+                or self.season_x_episode.match(initiator_raw)
+            )
+            if not matched:
+                continue
+
+            season = copy.copy(episode)
+            season.name = 'season'
+            season.value = int(matched.group('season'))
+            to_append.append(season)
+
+            expected_episode = int(matched.group('episode'))
+            if episode.value != expected_episode:
+                fixed_episode = copy.copy(episode)
+                fixed_episode.value = expected_episode
+                to_remove.append(episode)
+                to_append.append(fixed_episode)
+
+            to_remove.extend(
+                matches.named(
+                    'absolute_episode',
+                    predicate=lambda match: match.initiator is episode.initiator,
+                )
+            )
+            break
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class ExtractSeasonFromTitleSeasonWord(Rule):
+    """Pull ``Season N`` out of a title when ``Episode M`` is already present.
+
+    GuessIt 4 may fold ``Season.2`` into the title for patterns like
+    ``Ajin.Season.2.Episode.13``, leaving only an absolute-style episode.
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    title_season = re.compile(
+        r'^(?P<title>.+?)[\s._-]+Season[\s._-]*(?P<season>\d+)\.?$',
+        re.IGNORECASE,
+    )
+    episode_word = re.compile(r'^Episode[\s._-]*\d+$', re.IGNORECASE)
+    season_digits = re.compile(r'(?i)Season[\s._-]*(?P<season>\d+)')
+
+    def _has_episode_word_in_initiator(self, episode):
+        """Return True when the episode initiator is an explicit ``Episode`` token."""
+        initiator = episode.initiator
+        initiator_value = str(getattr(initiator, 'value', '') or '')
+        initiator_raw = str(getattr(initiator, 'raw', '') or '')
+        return bool(
+            self.episode_word.match(initiator_value)
+            or self.episode_word.match(initiator_raw)
+            or 'episode' in initiator_value.lower()
+        )
+
+    def _season_span_from_title(self, title, matches, matched, leading):
+        """Map ``(?P<season>\\d+)`` onto absolute input coordinates."""
+        season_start = title.start + leading + matched.start('season')
+        season_end = title.start + leading + matched.end('season')
+        if season_start < season_end:
+            return season_start, season_end
+
+        # Fallback when the primary match used a reformatted value string.
+        raw = matches.input_string[title.start:title.end]
+        digits = self.season_digits.search(raw)
+        if not digits:
+            return None
+        season_start = title.start + digits.start('season')
+        season_end = title.start + digits.end('season')
+        if season_start >= season_end:
+            return None
+        return season_start, season_end
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        titles = matches.named('title')
+        episodes = matches.named('episode')
+        if not titles or not episodes:
+            return
+
+        # Only rewrite when exactly one episode is tied to an ``Episode`` token.
+        # Titles like ``Show Season 2 - 09`` are handled by other anime rules.
+        episode_candidates = [
+            episode
+            for episode in episodes
+            if self._has_episode_word_in_initiator(episode)
+        ]
+        if len(episode_candidates) != 1:
+            return
+
+        episode = episode_candidates[0]
+
+        to_remove = []
+        to_append = []
+        for title in titles:
+            raw = matches.input_string[title.start:title.end]
+            leading = len(raw) - len(raw.lstrip())
+            matched = self.title_season.match(raw.strip())
+            if not matched:
+                # Value may already be separator-normalized (``.`` → space).
+                value = str(title.value)
+                leading = len(value) - len(value.lstrip())
+                matched = self.title_season.match(value.strip())
+                if not matched:
+                    continue
+
+            season_span = self._season_span_from_title(title, matches, matched, leading)
+            if not season_span:
+                continue
+            season_start, season_end = season_span
+
+            new_title = copy.copy(title)
+            new_title.value = matched.group('title').strip(' ._-\t')
+            to_remove.append(title)
+            to_append.append(new_title)
+
+            season = copy.copy(title)
+            season.name = 'season'
+            season.value = int(matched.group('season'))
+            season.start = season_start
+            season.end = season_end
+            to_append.append(season)
+
+            # Drop absolute numbering only for the Episode token we fixed.
+            to_remove.extend(
+                matches.named(
+                    'absolute_episode',
+                    predicate=lambda match: match.initiator is episode.initiator,
+                )
+            )
+            break
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class FixLeadingDashEpisodeTitle(Rule):
+    """Fix titles that are actually episode titles after an ``NNxNN`` pattern.
+
+    GuessIt 4 may assign ``Tommy's First Birthday`` as title when the series
+    name sits before an ``01x01`` token, while the episode title raw still
+    starts with a dash (`` - Tommy's First Birthday``).
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    leading_dash = re.compile(r'^\s*-+')
+    season_x_episode = re.compile(r'^\d+x\d+$', flags=re.IGNORECASE)
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        titles = matches.named('title')
+        if not titles:
+            return
+
+        episode_titles = matches.named('episode_title')
+        x_episodes = [
+            episode for episode in matches.named('episode')
+            if self.season_x_episode.match(str(getattr(episode.initiator, 'value', '') or ''))
+            or self.season_x_episode.match(str(getattr(episode.initiator, 'raw', '') or ''))
+        ]
+        if not x_episodes:
+            return
+
+        x_start = getattr(x_episodes[0].initiator, 'start', None)
+        if x_start is None:
+            x_start = x_episodes[0].start
+        series_title = None
+        series_start = None
+        series_end = None
+        for filepart in matches.markers.named('path'):
+            prefix = matches.input_string[filepart.start:x_start]
+            slash = max(prefix.rfind('/'), prefix.rfind('\\'))
+            segment_offset = slash + 1 if slash >= 0 else 0
+            segment = prefix[segment_offset:]
+            # Keep only the series name; drop separators immediately before NNxNN.
+            trimmed = re.sub(r'[\s._-]+$', '', segment).strip(' ._-\t')
+            if not trimmed:
+                continue
+
+            local_start = segment.find(trimmed)
+            if local_start < 0:
+                local_start = segment.lower().find(trimmed.lower())
+            if local_start < 0:
+                continue
+
+            candidate_start = filepart.start + segment_offset + local_start
+            candidate_end = candidate_start + len(trimmed)
+            if candidate_start > candidate_end or candidate_end > x_start:
+                continue
+
+            series_title = trimmed
+            series_start = candidate_start
+            series_end = candidate_end
+            break
+
+        if not series_title or series_start is None or series_end is None:
+            return
+        if series_start > series_end:
+            return
+
+        # Use GuessIt's title cleanup so "Show.Name" becomes "Show Name".
+        series_value = cleanup(series_title)
+
+        def _is_episode_like(title_match):
+            raw = title_match.raw or ''
+            if self.leading_dash.match(raw):
+                return True
+            if title_match.start >= x_episodes[0].end:
+                return True
+            return False
+
+        episode_like_titles = [
+            title for title in titles
+            if _is_episode_like(title) and str(title.value) != series_value
+        ]
+        span_fix_titles = [
+            title for title in titles
+            if str(title.value) == series_value
+            and (title.start != series_start or title.end != series_end)
+        ]
+        # Title hole absorbed the NNxNN token (e.g. value "Rugrats 01x01").
+        overreaching_titles = [
+            title for title in titles
+            if title.end > series_end
+            and str(title.value).lower().startswith(series_value.lower())
+            and str(title.value) != series_value
+        ]
+        # Do not rewrite ordinary Sxx/NNxNN releases that already have a clean title.
+        if not episode_like_titles and not span_fix_titles and not overreaching_titles:
+            return
+
+        to_remove = []
+        to_append = []
+
+        # Demote misdetected titles that are actually episode titles.
+        for title in episode_like_titles:
+            already_has_ep = any(
+                str(ep.value) == self.leading_dash.sub('', str(title.value)).strip()
+                for ep in episode_titles
+            )
+            if not already_has_ep and not episode_titles:
+                episode_title = copy.copy(title)
+                episode_title.name = 'episode_title'
+                episode_title.value = self.leading_dash.sub('', str(title.value)).strip()
+                to_append.append(episode_title)
+            elif episode_titles:
+                for candidate in episode_titles:
+                    if self.leading_dash.match(candidate.raw or ''):
+                        fixed_ep = copy.copy(candidate)
+                        fixed_ep.value = self.leading_dash.sub('', str(candidate.value)).strip()
+                        to_remove.append(candidate)
+                        to_append.append(fixed_ep)
+                        break
+
+            to_remove.append(title)
+
+        for title in span_fix_titles + overreaching_titles:
+            to_remove.append(title)
+
+        precise_exists = any(
+            str(title.value) == series_value
+            and title.start == series_start
+            and title.end == series_end
+            for title in titles
+            if title not in to_remove
+        )
+        if not precise_exists:
+            new_title = copy.copy(titles[0])
+            new_title.name = 'title'
+            new_title.value = series_value
+            new_title.start = series_start
+            new_title.end = series_end
+            to_append.append(new_title)
+
+        if to_remove or to_append:
+            return to_remove, to_append
+
+
+class DemoteOrphanReleaseGroupToEpisodeTitle(Rule):
+    """Demote a trailing bare release_group to episode_title when appropriate.
+
+    GuessIt 4 may classify an episode title after technical tags as a scene
+    release group (e.g. ``... EAC3-6ch) River.mkv``).
+
+    Only demote when the group is a single token immediately after a closing
+    parenthesis that follows technical properties. Regular scene groups must
+    remain untouched.
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+    tech_names = {
+        'screen_size',
+        'source',
+        'video_codec',
+        'video_profile',
+        'video_encoder',
+        'audio_codec',
+        'audio_channels',
+        'other',
+        'date',
+    }
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('episode_title'):
+            return
+
+        release_groups = matches.named('release_group')
+        if not release_groups or len(release_groups) != 1:
+            return
+
+        release_group = release_groups[0]
+        value = str(release_group.value or '').strip()
+        if not value or '-' in value or '[' in value or ' ' in value:
+            return
+        if not value[0].isupper():
+            return
+
+        previous = matches.previous(
+            release_group,
+            index=-1,
+            predicate=lambda match: match.name in self.tech_names,
+        )
+        if not previous:
+            return
+
+        # GuessIt may absorb ``)`` into the previous tech match, leaving no hole.
+        lookbehind = matches.input_string[max(0, release_group.start - 3):release_group.start]
+        hole = matches.holes(start=previous.end, end=release_group.start, index=0)
+        between = matches.input_string[previous.end:release_group.start]
+        if ')' not in lookbehind and ')' not in between and not (hole and ')' in hole.value):
+            return
+
+        episode_title = copy.copy(release_group)
+        episode_title.name = 'episode_title'
+        return [release_group], [episode_title]
+
+
+class RemoveTechBrandEpisodeTitle(Rule):
+    """Remove all-caps tech brands misdetected as episode_title.
+
+    GuessIt 4 may treat tokens like ``VISIONPLUS`` between a title and an
+    absolute episode number as an episode title. Those brands are not titles.
+    """
+
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+    all_caps_token = re.compile(r'^[A-Z][A-Z0-9+]{2,}$')
+
+    def when(self, matches, context):
+        """Evaluate the rule."""
+        if matches.named('season'):
+            return
+
+        episode_titles = matches.named('episode_title')
+        if not episode_titles or not matches.named('absolute_episode'):
+            return
+
+        to_remove = []
+        for episode_title in episode_titles:
+            if not self.all_caps_token.match(str(episode_title.value)):
+                continue
+            previous_title = matches.range(
+                0,
+                episode_title.start,
+                predicate=lambda match: match.name == 'title',
+                index=-1,
+            )
+            next_episode = matches.range(
+                episode_title.end,
+                len(matches.input_string),
+                predicate=lambda match: match.name in ('episode', 'absolute_episode'),
+                index=0,
+            )
+            if previous_title and next_episode:
+                to_remove.append(episode_title)
+
+        return to_remove
 
 
 class AbsoluteEpisodeWithX26Y(Rule):
@@ -1390,13 +1927,34 @@ class FixEpisodeTitleAsMultiSeason(Rule):
             return
 
         seasons = matches.named('season')
-        if not seasons or len(seasons) not in [2, 3]:
+        if not seasons or len(seasons) < 2:
             return
 
-        if len(seasons) == 2:
-            season = seasons[-1]
+        episodes = matches.named('episode')
+        # Prefer seasons that appear after an explicit episode and are not part of
+        # the same SxxExx initiator (GuessIt 4 may tag "1.x265" / ".3.x265" as
+        # SxxExx, which wrongly looks like a strong season marker).
+        weak_seasons = []
+        if episodes:
+            for episode in episodes:
+                weak_seasons.extend(
+                    season for season in seasons
+                    if season.start >= episode.end
+                    and season.parent is not episode.parent
+                )
+        if not weak_seasons:
+            weak_seasons = [
+                season for season in seasons
+                if 'SxxExx' not in season.tags
+            ]
+        if not weak_seasons:
+            # Fallback for the GuessIt 3 shape: exactly 2-3 seasons, take the last
+            # weak-looking one from the historical selection rules.
+            if len(seasons) not in [2, 3]:
+                return
+            season = seasons[-1] if len(seasons) == 2 else seasons[len(seasons) - 2]
         else:
-            season = seasons[len(seasons) - 2]
+            season = weak_seasons[-1]
 
         next_episode = matches.next(season, predicate=lambda match: match.name == 'episode')
         if next_episode:
@@ -1411,7 +1969,7 @@ class FixEpisodeTitleAsMultiSeason(Rule):
                 return
 
             episode_title = episode_titles[0]
-            if not episode_title.value[0].isdigit():
+            if not str(episode_title.value)[0].isdigit():
                 episode_title.value = episode_title.value + ' ' + str(season.value)
             to_remove.append(season)
         else:
@@ -1611,6 +2169,18 @@ class FixParentFolderReplacingTitle(Rule):
                     to_append = episode_title
                     to_remove = None
                     return to_remove, to_append
+
+                # Parent folder like "Rugrats Season 1" already matches the title,
+                # and the filename also contains that series title. Keep it.
+                folder_series = re.sub(
+                    r'[\s._-]*[Ss]eason[\s._-]*\d+$',
+                    '',
+                    second_part,
+                ).strip(' ._-\t')
+                if folder_series and folder_series.lower() == str(title[0].value).lower():
+                    filename = fileparts[parts_len - 1].value.replace('.', ' ').lower()
+                    if str(title[0].value).lower() in filename:
+                        return
 
                 if second_part.startswith(title[0].value):
                     season = matches.named('season')
@@ -2004,6 +2574,9 @@ def rules():
         AnimeWithSeasonMultipleEpisodeNumbers,
         AnimeWithMultipleSeasons,
         AnimeAbsoluteEpisodeNumbers,
+        RestoreSeasonFromXPattern,
+        ExtractSeasonFromTitleSeasonWord,
+        FixLeadingDashEpisodeTitle,
         AbsoluteEpisodeNumbers,
         AbsoluteEpisodeWithX26Y,
         FixEpisodeTitleAsMultiSeason,
@@ -2015,6 +2588,8 @@ def rules():
         FixTitlesThatExistOfAbsoluteEpisodeNumbers,
         FixTitlesThatExistOfYearNumbers,
         ReleaseGroupPostProcessor,
+        DemoteOrphanReleaseGroupToEpisodeTitle,
+        RemoveTechBrandEpisodeTitle,
         FixParentFolderReplacingTitle,
         FixMultipleSources,
         AudioCodecStandardizer,

--- a/medusa/name_parser/series_name.py
+++ b/medusa/name_parser/series_name.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+"""Series name comparison helpers for GuessIt integration."""
+from __future__ import unicode_literals
+
+import unicodedata
+
+from medusa.helpers import full_sanitize_scene_name
+
+
+def normalize_series_name_for_comparison(name):
+    """Normalize a series title for equality checks only.
+
+    GuessIt 4 may return more accurate punctuation than GuessIt 3
+    (``11.22.63``, ``R-15``, ``9-1-1``). Keep those raw values in parser
+    output; use this helper when matching against the library or aliases.
+
+    Applies Unicode NFKD (strip combining marks) then
+    :func:`medusa.helpers.full_sanitize_scene_name`, which folds case, dots,
+    hyphens and ordinary separators for scene matching.
+    """
+    if not name:
+        return ''
+
+    decomposed = unicodedata.normalize('NFKD', name)
+    without_marks = ''.join(
+        char for char in decomposed
+        if not unicodedata.combining(char)
+    )
+    return full_sanitize_scene_name(without_marks)

--- a/medusa/name_parser/series_name.py
+++ b/medusa/name_parser/series_name.py
@@ -8,11 +8,12 @@ from medusa.helpers import full_sanitize_scene_name
 
 
 def normalize_series_name_for_comparison(name):
-    """Normalize a series title for equality checks only.
+    """Normalize a series title for library/alias matching and cache keys.
 
     GuessIt 4 may return more accurate punctuation than GuessIt 3
     (``11.22.63``, ``R-15``, ``9-1-1``). Keep those raw values in parser
-    output; use this helper when matching against the library or aliases.
+    output; use this helper when matching against the library or aliases,
+    and when building persistent keys in :mod:`medusa.name_cache`.
 
     Applies Unicode NFKD (strip combining marks) then
     :func:`medusa.helpers.full_sanitize_scene_name`, which folds case, dots,

--- a/tests/name_parser/test_expected_punctuation.py
+++ b/tests/name_parser/test_expected_punctuation.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Tests for GuessIt expected_title / expected_group Medusa monkeypatch."""
+from __future__ import unicode_literals
+
+import pytest
+
+from medusa import app
+from medusa.name_parser import guessit_parser as sut
+
+
+@pytest.fixture
+def punctuated_shows(create_tvshow, monkeypatch):
+    shows = [
+        create_tvshow(indexerid=2, name='11.22.63'),
+        create_tvshow(indexerid=9, name='R-15'),
+        create_tvshow(indexerid=19, name='9-1-1'),
+    ]
+    monkeypatch.setattr(app, 'showList', shows)
+    # Options include expected_title lists; clear so titles from this fixture apply.
+    sut.guessit_cache.clear()
+    return shows
+
+
+@pytest.mark.parametrize('release_name,expected_title', [
+    ('11.22.63.S01E06.720p', '11.22.63'),
+    ('R-15.S03E04', 'R-15'),
+    ('9-1-1.S01E01.720p.HDTV.x264-GROUP', '9-1-1'),
+])
+def test_expected_title_keeps_punctuation(punctuated_shows, release_name, expected_title):
+    """GuessIt 4 must not space-collapse punctuated expected titles."""
+    result = sut.guessit(release_name, cached=False)
+    assert result.get('title') == expected_title
+
+
+def test_expected_group_keeps_punctuation(punctuated_shows):
+    """Numeric release groups like 20-40 must keep their hyphen."""
+    result = sut.guessit(
+        'Show.Name.Season.6.480p.HDTV.H264-20-40.WEB-DL',
+        cached=False,
+    )
+    assert result.get('release_group') == '20-40'

--- a/tests/name_parser/test_extract_season_from_title_season_word.py
+++ b/tests/name_parser/test_extract_season_from_title_season_word.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+"""Tests for ExtractSeasonFromTitleSeasonWord GuessIt 4 adaptation."""
+from __future__ import unicode_literals
+
+from rebulk.match import Match, Matches
+
+from medusa.name_parser import guessit_parser as sut
+from medusa.name_parser.rules.rules import ExtractSeasonFromTitleSeasonWord
+
+
+def _episode_with_initiator(start, end, value, initiator_value, initiator_start=None, initiator_end=None,
+                            input_string=None):
+    """Build an episode Match whose initiator carries an Episode token."""
+    initiator_start = start if initiator_start is None else initiator_start
+    initiator_end = end if initiator_end is None else initiator_end
+    initiator = Match(
+        initiator_start,
+        initiator_end,
+        value=initiator_value,
+        name='episode',
+        input_string=input_string,
+    )
+    return Match(
+        start,
+        end,
+        value=value,
+        name='episode',
+        parent=initiator,
+        input_string=input_string,
+    )
+
+
+def test_rule_requires_unique_episode_token_initiator():
+    """Multiple Episode-token episodes must abort the rewrite."""
+    text = 'Ajin Season 2 Episode 13 Episode 14'
+    title = Match(0, 12, value='Ajin Season 2', name='title', input_string=text)
+    episode_a = _episode_with_initiator(13, 23, 13, 'Episode 13', 13, 23, text)
+    episode_b = _episode_with_initiator(24, 34, 14, 'Episode 14', 24, 34, text)
+    matches = Matches([title, episode_a, episode_b], input_string=text)
+
+    assert ExtractSeasonFromTitleSeasonWord().when(matches, {}) is None
+
+
+def test_rule_removes_only_absolute_episode_for_same_initiator():
+    """Unrelated absolute_episode matches must be preserved."""
+    text = 'Ajin Season 2 Episode 13 extra 99'
+    title = Match(0, 12, value='Ajin Season 2', name='title', input_string=text)
+    episode = _episode_with_initiator(13, 23, 13, 'Episode 13', 13, 23, text)
+    same_abs = Match(21, 23, value=13, name='absolute_episode', parent=episode.initiator, input_string=text)
+    other_init = Match(30, 32, value='99', name='episode', input_string=text)
+    other_abs = Match(30, 32, value=99, name='absolute_episode', parent=other_init, input_string=text)
+    matches = Matches([title, episode, same_abs, other_abs], input_string=text)
+
+    to_remove, to_append = ExtractSeasonFromTitleSeasonWord().when(matches, {})
+    removed_absolute = [match for match in to_remove if match.name == 'absolute_episode']
+    assert removed_absolute == [same_abs]
+    assert other_abs not in to_remove
+
+    seasons = [match for match in to_append if match.name == 'season']
+    assert len(seasons) == 1
+    assert seasons[0].value == 2
+
+
+def test_rule_season_span_covers_digits_only():
+    """Season match span must cover only the captured season digits."""
+    text = 'Ajin.Season.2.Episode.13'
+    title = Match(0, 13, value='Ajin Season 2', name='title', input_string=text)
+    episode = _episode_with_initiator(14, 24, 13, 'Episode 13', 14, 24, text)
+    matches = Matches([title, episode], input_string=text)
+
+    _to_remove, to_append = ExtractSeasonFromTitleSeasonWord().when(matches, {})
+    season = next(match for match in to_append if match.name == 'season')
+
+    assert season.value == 2
+    assert season.start < season.end
+    assert text[season.start:season.end] == '2'
+    assert season.start == text.index('2')
+    assert season.end == season.start + 1
+
+
+def test_guessit_ajin_season_episode_pattern():
+    """End-to-end: Season+Episode release keeps title/season/episode identity."""
+    result = sut.guessit(
+        '[Ajin2.com].Ajin.Season.2.Episode.13.[End].[720p].[Subbed]',
+        cached=False,
+    )
+    assert result.get('title') == 'Ajin'
+    assert result.get('season') == 2
+    assert result.get('episode') == 13

--- a/tests/name_parser/test_fix_episode_title_as_multi_season.py
+++ b/tests/name_parser/test_fix_episode_title_as_multi_season.py
@@ -50,6 +50,50 @@ def test_existing_episode_title_uses_copies_not_mutation():
     assert weak_season.value == 1
 
 
+def test_updates_previous_episode_title_not_first_match():
+    """When multiple episode_title matches exist, only the one before the weak season changes."""
+    text = 'Show.Name.S09E06.First.Trust.No.1.mkv'
+    early_title = Match(16, 21, value='First', name='episode_title', input_string=text)
+    near_title = Match(22, 30, value='Trust No', name='episode_title', input_string=text)
+    weak_season = Match(31, 32, value=1, name='season', input_string=text)
+    matches = Matches([
+        Match(0, 9, value='Show Name', name='title', input_string=text),
+        Match(10, 12, value=9, name='season', input_string=text, tags=['SxxExx']),
+        Match(13, 15, value=6, name='episode', input_string=text, tags=['SxxExx']),
+        early_title,
+        near_title,
+        weak_season,
+    ], input_string=text)
+
+    to_remove, to_append = FixEpisodeTitleAsMultiSeason().when(matches, {})
+    assert early_title not in to_remove
+    assert near_title in to_remove
+    fixed = next(match for match in to_append if match.name == 'episode_title')
+    assert fixed.value == 'Trust No 1'
+    assert early_title.value == 'First'
+
+
+def test_empty_episode_title_does_not_raise():
+    """Empty episode_title values must not raise IndexError."""
+    text = 'Show.Name.S01E02..1.mkv'
+    empty_title = Match(16, 16, value='', name='episode_title', input_string=text)
+    weak_season = Match(17, 18, value=1, name='season', input_string=text)
+    matches = Matches([
+        Match(0, 9, value='Show Name', name='title', input_string=text),
+        Match(10, 12, value=1, name='season', input_string=text, tags=['SxxExx']),
+        Match(13, 15, value=2, name='episode', input_string=text, tags=['SxxExx']),
+        empty_title,
+        weak_season,
+    ], input_string=text)
+
+    result = FixEpisodeTitleAsMultiSeason().when(matches, {})
+    assert result is not None
+    to_remove, to_append = result
+    assert weak_season in to_remove
+    assert empty_title not in to_remove
+    assert not any(match.name == 'episode_title' for match in to_append)
+
+
 def test_missing_episode_title_appends_copy_instead_of_mutating_season():
     """Weak season becomes a new episode_title copy; original season stays intact."""
     text = 'Show.Name.S01E02.3.mkv'

--- a/tests/name_parser/test_fix_episode_title_as_multi_season.py
+++ b/tests/name_parser/test_fix_episode_title_as_multi_season.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+"""Tests for FixEpisodeTitleAsMultiSeason without in-place match mutation."""
+from __future__ import unicode_literals
+
+import copy
+
+from rebulk.match import Match, Matches
+
+from medusa.name_parser import guessit_parser as sut
+from medusa.name_parser.rules.rules import FixEpisodeTitleAsMultiSeason
+
+
+def test_end_to_end_xflies_trust_no_1():
+    """Weak trailing season digit is folded into the episode title."""
+    result = sut.guessit(
+        'The.X-Flies.S09E06.Trust.No.1.x265.HEVC-Qman[UTR].mkv',
+        cached=False,
+    )
+    assert result.get('season') == 9
+    assert result.get('episode') == 6
+    assert result.get('episode_title') == 'Trust No 1'
+
+
+def test_existing_episode_title_uses_copies_not_mutation():
+    """Existing episode_title must be replaced via remove/append copies."""
+    text = 'Show.Name.S09E06.Trust.No.1.mkv'
+    title = Match(0, 9, value='Show Name', name='title', input_string=text)
+    season_main = Match(10, 12, value=9, name='season', input_string=text, tags=['SxxExx'])
+    episode = Match(13, 15, value=6, name='episode', input_string=text, tags=['SxxExx'])
+    episode_title = Match(16, 24, value='Trust No', name='episode_title', input_string=text)
+    weak_season = Match(25, 26, value=1, name='season', input_string=text)
+    original_title_value = episode_title.value
+    original_title_id = id(episode_title)
+    original_weak_id = id(weak_season)
+
+    matches = Matches(
+        [title, season_main, episode, episode_title, weak_season],
+        input_string=text,
+    )
+    to_remove, to_append = FixEpisodeTitleAsMultiSeason().when(matches, {})
+
+    assert weak_season in to_remove
+    assert episode_title in to_remove
+    fixed = next(match for match in to_append if match.name == 'episode_title')
+    assert fixed.value == 'Trust No 1'
+    assert id(fixed) != original_title_id
+    assert episode_title.value == original_title_value
+    assert id(weak_season) == original_weak_id
+    assert weak_season.name == 'season'
+    assert weak_season.value == 1
+
+
+def test_missing_episode_title_appends_copy_instead_of_mutating_season():
+    """Weak season becomes a new episode_title copy; original season stays intact."""
+    text = 'Show.Name.S01E02.3.mkv'
+    title = Match(0, 9, value='Show Name', name='title', input_string=text)
+    season_main = Match(10, 12, value=1, name='season', input_string=text, tags=['SxxExx'])
+    episode = Match(13, 15, value=2, name='episode', input_string=text, tags=['SxxExx'])
+    weak_season = Match(16, 17, value=3, name='season', input_string=text)
+    original = copy.copy(weak_season)
+
+    matches = Matches([title, season_main, episode, weak_season], input_string=text)
+    to_remove, to_append = FixEpisodeTitleAsMultiSeason().when(matches, {})
+
+    assert weak_season in to_remove
+    assert weak_season.name == 'season'
+    assert weak_season.value == original.value
+    new_title = next(match for match in to_append if match.name == 'episode_title')
+    assert new_title.value == '3'
+    assert id(new_title) != id(weak_season)
+
+
+def test_anime_context_skips_rule():
+    """Anime shows must not trigger the multi-season title rewrite."""
+    text = 'Show.Name.S01E02.3.mkv'
+    matches = Matches([
+        Match(0, 9, value='Show Name', name='title', input_string=text),
+        Match(10, 12, value=1, name='season', input_string=text, tags=['SxxExx']),
+        Match(13, 15, value=2, name='episode', input_string=text, tags=['SxxExx']),
+        Match(16, 17, value=3, name='season', input_string=text),
+    ], input_string=text)
+
+    assert FixEpisodeTitleAsMultiSeason().when(matches, {'show_type': 'anime'}) is None
+
+
+def test_strong_second_sxxexx_is_not_removed():
+    """A real second SxxExx season must not be treated as a weak title digit."""
+    text = 'Show.Name.S01E02.S02E03.mkv'
+    season1 = Match(10, 12, value=1, name='season', input_string=text, tags=['SxxExx'])
+    episode1 = Match(13, 15, value=2, name='episode', input_string=text, tags=['SxxExx'])
+    season2 = Match(16, 18, value=2, name='season', input_string=text, tags=['SxxExx'])
+    episode2 = Match(19, 21, value=3, name='episode', input_string=text, tags=['SxxExx'])
+    # Link second season/episode as siblings under same parent initiator shape
+    parent = Match(16, 21, value='S02E03', name='episode', input_string=text)
+    season2.parent = parent
+    episode2.parent = parent
+
+    matches = Matches([
+        Match(0, 9, value='Show Name', name='title', input_string=text),
+        season1, episode1, season2, episode2,
+    ], input_string=text)
+
+    # next_episode after season2 exists -> rule returns None
+    assert FixEpisodeTitleAsMultiSeason().when(matches, {}) is None

--- a/tests/name_parser/test_fix_leading_dash_title.py
+++ b/tests/name_parser/test_fix_leading_dash_title.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+"""Tests for FixLeadingDashEpisodeTitle span handling."""
+from __future__ import unicode_literals
+
+from medusa import app
+from medusa.name_parser import guessit_parser as sut
+from medusa.name_parser.rules import default_api
+
+
+def test_fix_leading_dash_episode_title_span():
+    """Series title span must be valid and stop before the NNxNN token."""
+    release = "Rugrats Season 1/Rugrats - 01x01 - Tommy's First Birthday[JM].avi"
+    result = sut.guessit(release, cached=False)
+
+    assert result.get('title') == 'Rugrats'
+    assert result.get('episode_title') == "Tommy's First Birthday"
+    assert result.get('season') == 1
+    assert result.get('episode') == 1
+
+    matches = default_api.rebulk.matches(
+        release,
+        {
+            'type': 'episode',
+            'implicit': True,
+            'expected_title': sut.get_expected_titles(app.showList),
+            'expected_group': sut.expected_groups,
+        },
+    )
+    series_titles = [
+        match for match in matches.named('title')
+        if match.value == 'Rugrats'
+    ]
+    assert series_titles
+    for match in series_titles:
+        assert match.start <= match.end
+        span_text = release[match.start:match.end]
+        assert span_text == 'Rugrats'
+        assert '01x01' not in span_text
+        assert not span_text.endswith('-')
+        assert not span_text.endswith(' ')

--- a/tests/name_parser/test_restore_season_from_x_pattern.py
+++ b/tests/name_parser/test_restore_season_from_x_pattern.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""Tests for RestoreSeasonFromXPattern span restoration."""
+from __future__ import unicode_literals
+
+from rebulk.match import Match, Matches
+
+from medusa.name_parser import guessit_parser as sut
+from medusa.name_parser.rules.rules import RestoreSeasonFromXPattern
+
+
+def test_restore_season_span_covers_digits_only():
+    """Season/episode spans must cover only the NNxNN digit groups."""
+    text = 'Rugrats - 01x02 - Episode title.mkv'
+    idx = text.index('01x02')
+    initiator = Match(idx, idx + 5, value='01x02', name='episode', input_string=text)
+    # Simulate GuessIt keeping a single episode child spanning the whole initiator.
+    episode = Match(
+        idx, idx + 5, value=2, name='episode', parent=initiator,
+        input_string=text, tags=['SxxExx'],
+    )
+    matches = Matches([
+        Match(0, 7, value='Rugrats', name='title', input_string=text),
+        episode,
+    ], input_string=text)
+
+    to_remove, to_append = RestoreSeasonFromXPattern().when(matches, {})
+    season = next(match for match in to_append if match.name == 'season')
+    fixed_episode = next(match for match in to_append if match.name == 'episode')
+
+    assert season.value == 1
+    assert fixed_episode.value == 2
+    assert season.start < season.end
+    assert fixed_episode.start < fixed_episode.end
+    assert text[season.start:season.end] == '01'
+    assert text[fixed_episode.start:fixed_episode.end] == '02'
+    assert episode in to_remove
+
+
+def test_restore_season_span_with_windows_path():
+    """Absolute coordinates must remain correct inside a Windows path."""
+    text = r'C:\TV\Rugrats Season 1\Rugrats - 01x02 - Episode title.mkv'
+    idx = text.index('01x02')
+    initiator = Match(idx, idx + 5, value='01x02', raw='01x02', name='episode', input_string=text)
+    episode = Match(
+        idx, idx + 5, value=2, name='episode', parent=initiator,
+        input_string=text, tags=['SxxExx'],
+    )
+    matches = Matches([episode], input_string=text)
+
+    _to_remove, to_append = RestoreSeasonFromXPattern().when(matches, {})
+    season = next(match for match in to_append if match.name == 'season')
+    fixed_episode = next(match for match in to_append if match.name == 'episode')
+
+    assert season.value == 1
+    assert fixed_episode.value == 2
+    assert text[season.start:season.end] == '01'
+    assert text[fixed_episode.start:fixed_episode.end] == '02'
+
+
+def test_restore_season_end_to_end_guessit():
+    """End-to-end parse keeps season/episode identity for Rugrats NNxNN."""
+    result = sut.guessit('Rugrats - 01x02 - Episode title.mkv', cached=False)
+    assert result.get('title') == 'Rugrats'
+    assert result.get('season') == 1
+    assert result.get('episode') == 2

--- a/tests/name_parser/test_series_name.py
+++ b/tests/name_parser/test_series_name.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Tests for series name comparison normalization."""
+from __future__ import unicode_literals
+
+import pytest
+
+from medusa.name_parser.series_name import normalize_series_name_for_comparison
+
+
+@pytest.mark.parametrize('raw,library', [
+    ('11.22.63', '11 22 63'),
+    ('11.22.63', '11.22.63'),
+    ('R-15', 'R 15'),
+    ('R-15', 'R-15'),
+    ('9-1-1', '9 1 1'),
+    ('9-1-1', '9-1-1'),
+    ('12 Monkeys', '12.Monkeys'),
+    ('3 Show på (abc2)', '3 Show pa (abc2)'),
+    ('1923 (2022)', '1923 2022'),
+    ('1883 (2021)', '1883 2021'),
+])
+def test_normalize_series_name_for_comparison_matches_guessit4_titles(raw, library):
+    """Punctuated GuessIt 4 titles must still match library / alias forms."""
+    assert normalize_series_name_for_comparison(raw) == normalize_series_name_for_comparison(library)
+
+
+@pytest.mark.parametrize('left,right', [
+    ('11.22.63', 'The 100'),
+    ('R-15', 'R-16'),
+    ('9-1-1', '911'),
+    ('1923', '1883'),
+    ('1923 (2022)', '1883 (2021)'),
+])
+def test_normalize_series_name_for_comparison_keeps_distinct_shows(left, right):
+    """Normalization must not collapse clearly different series names."""
+    assert normalize_series_name_for_comparison(left) != normalize_series_name_for_comparison(right)
+
+
+def test_normalize_preserves_empty():
+    assert normalize_series_name_for_comparison('') == ''
+    assert normalize_series_name_for_comparison(None) == ''

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -1768,6 +1768,7 @@
   video_codec: H.264
   video_encoder: x264
   release_group: GROUP
+  container: rar
   mimetype: application/rar
   type: episode
 
@@ -1878,6 +1879,7 @@
   season: 2
   episode: 5
   other: Formula One
+  episode_title: Special
   episode_details: Special
   screen_size: 720p
   source: HDTV
@@ -1949,11 +1951,21 @@
 
 # CreateAliasWithAlternativeTitles (separated by +)
 ? - "[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]"
-  - /Shows/Show Name - Still+Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
   - /Shows/Show Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
 : title: Show Name
   alternative_title: [Still, Name]
   alias: "Show Name - Still+Name"
+  absolute_episode: 11
+  episode: 11
+  screen_size: 1080p
+  release_group: SuperGroup
+  type: episode
+
+? /Shows/Show Name - Still+Name/[SuperGroup].Show.Name.-.Still+Name.-.11.[1080p]
+: title: Show Name
+  alternative_title: [Still, Name]
+  alias: "Show Name - Still+Name"
+  episode_title: Still Name
   absolute_episode: 11
   episode: 11
   screen_size: 1080p
@@ -2176,6 +2188,7 @@
   video_encoder: x264
   release_group: C4TV
   language: en
+  episode_title: Special
   episode_details: Special
   type: episode
 
@@ -4551,7 +4564,7 @@
   screen_size: 1080p
   video_codec: H.265
   video_encoder: x265
-  release_group: eztv
+  release_group: MeGusta
   container: mkv
   video_profile: 'High Efficiency Video Coding'
   other: Proper
@@ -4563,6 +4576,7 @@
 ? /1883 (2021)/Season 01/1883 (2021) (S01E03) (2021-12-26) (1080p-AVC BluRay EAC3-6ch) River.mkv
 : title: "1883"
   year: 2021
+  alias: "1883 2021"
   season: 1
   episode: 3
   date: 2021-12-26
@@ -4573,6 +4587,7 @@
   audio_codec: 'Dolby Digital Plus'
   audio_channels: '5.1'
   video_profile: 'Advanced Video Codec High Definition'
+  episode_title: River
   type: episode
 
 
@@ -4592,6 +4607,7 @@
   season: 1
   episode: 1
   year: 2022
+  alias: "1923 2022"
   screen_size: 720p
   video_codec: H.264
   release_group: Group


### PR DESCRIPTION
## Summary

Review layer: Medusa-side GuessIt 4 adaptations (parser rules, series name normalization, regression tests).

Includes Copilot follow-ups previously landed in `b28af18db` on `chore/update-guessit` (see closed satellite review `Mika3578/Medusa#30`).

## Base

Stacked on `review/guessit4-vendor-runtime` (#34).

## Stack

1. #33 — Python 3.10
2. #36 — remove unused vendored test suites
3. #34 — GuessIt/Rebulk runtime
4. **#35** — Medusa integration *(this PR)*

## Scope

- `medusa/name_cache.py`
- `medusa/name_parser/rules/__init__.py`
- `medusa/name_parser/rules/expected_patch.py`
- `medusa/name_parser/rules/rules.py`
- `medusa/name_parser/series_name.py`
- `tests/name_parser/test_expected_punctuation.py`
- `tests/name_parser/test_extract_season_from_title_season_word.py`
- `tests/name_parser/test_fix_episode_title_as_multi_season.py`
- `tests/name_parser/test_fix_leading_dash_title.py`
- `tests/name_parser/test_restore_season_from_x_pattern.py`
- `tests/name_parser/test_series_name.py`
- `tests/test_guessit.yml`

## Validation (local)

- Focused GuessIt + name-parser: **525 passed** (Python 3.10 and 3.11)
- Complete suite: **1163 passed, 1 xfailed** (Python 3.10 and 3.11)
- `git diff --check`: clean

## Head

`6c74e3eb4` — follow-up for Copilot review of `954000700`:
- use `previous` episode_title (not `episode_titles[0]`)
- guard empty episode_title values
- clarify `normalize_series_name_for_comparison` docstring (library/alias + name_cache keys)

Please re-request Copilot on this HEAD via the GitHub UI.

## Notes

- Closed Copilot satellite: https://github.com/Mika3578/Medusa/pull/30
- Aggregated migration archive: `archive/guessit4-full` (`b28af18db`)
- Draft review only — do not merge alone into `develop`

## Rollback

Close draft. Keep `archive/guessit4-full` and existing aggregated PR untouched until maintainers decide.
